### PR TITLE
[SCRUM-104] Enabled CloudFront standard logging for debugging

### DIFF
--- a/terraform/cloudfront_for_apis/.terraform.lock.hcl
+++ b/terraform/cloudfront_for_apis/.terraform.lock.hcl
@@ -23,3 +23,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:fdb98a53500e245a3b5bec077b994da6959dba8fc4eb7534528658d820e06bd5",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.6.2"
+  hashes = [
+    "h1:5lstwe/L8AZS/CP0lil2nPvmbbjAu8kCaU/ogSGNbxk=",
+    "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
+    "zh:1bcd2d8161e89e39886119965ef0f37fcce2da9c1aca34263dd3002ba05fcb53",
+    "zh:37c75d15e9514556a5f4ed02e1548aaa95c0ecd6ff9af1119ac905144c70c114",
+    "zh:4210550a767226976bc7e57d988b9ce48f4411fa8a60cd74a6b246baf7589dad",
+    "zh:562007382520cd4baa7320f35e1370ffe84e46ed4e2071fdc7e4b1a9b1f8ae9b",
+    "zh:5efb9da90f665e43f22c2e13e0ce48e86cae2d960aaf1abf721b497f32025916",
+    "zh:6f71257a6b1218d02a573fc9bff0657410404fb2ef23bc66ae8cd968f98d5ff6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9647e18f221380a85f2f0ab387c68fdafd58af6193a932417299cdcae4710150",
+    "zh:bb6297ce412c3c2fa9fec726114e5e0508dd2638cad6a0cb433194930c97a544",
+    "zh:f83e925ed73ff8a5ef6e3608ad9225baa5376446349572c2449c0c0b3cf184b7",
+    "zh:fbef0781cb64de76b1df1ca11078aecba7800d82fd4a956302734999cfd9a4af",
+  ]
+}

--- a/terraform/cloudfront_for_apis/cloudfront.tf
+++ b/terraform/cloudfront_for_apis/cloudfront.tf
@@ -36,7 +36,7 @@ module "cloudfront" {
     compress                 = true
     query_string             = true
     cache_policy_id          = aws_cloudfront_cache_policy.no_cache_policy.id # Use no-cache policy
-    origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3"
+    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
     use_forwarded_values     = false
   }
 
@@ -51,7 +51,7 @@ module "cloudfront" {
       compress                 = true
       query_string             = true
       cache_policy_id          = aws_cloudfront_cache_policy.no_cache_policy.id
-      origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3"
+      origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
       use_forwarded_values     = false
     }
   ]

--- a/terraform/cloudfront_for_apis/cloudfront.tf
+++ b/terraform/cloudfront_for_apis/cloudfront.tf
@@ -11,6 +11,11 @@ module "cloudfront" {
   retain_on_delete    = false
   wait_for_deployment = false
 
+  logging_config = {
+    bucket = module.log_bucket.s3_bucket_bucket_domain_name
+    prefix = "cloudfront"
+  }
+
   origin = {
     for o in var.api_gateway_origins : o.domain_name => {
       domain_name = o.domain_name

--- a/terraform/cloudfront_for_apis/s3.tf
+++ b/terraform/cloudfront_for_apis/s3.tf
@@ -1,0 +1,32 @@
+data "aws_canonical_user_id" "current" {}
+data "aws_cloudfront_log_delivery_canonical_user_id" "cloudfront" {}
+
+resource "random_string" "this" {
+  length  = 4
+  special = false
+  lower   = true
+  upper   = false
+}
+
+module "log_bucket" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "~> 4.1"
+
+  bucket = "aws-educate-tpet-cloudfront-logs-${random_string.this.result}"
+
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
+
+  grant = [{
+    type       = "CanonicalUser"
+    permission = "FULL_CONTROL"
+    id         = data.aws_canonical_user_id.current.id
+    }, {
+    type       = "CanonicalUser"
+    permission = "FULL_CONTROL"
+    id         = data.aws_cloudfront_log_delivery_canonical_user_id.cloudfront.id
+    # Ref. https://github.com/terraform-providers/terraform-provider-aws/issues/12512
+    # Ref. https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html
+  }]
+  force_destroy = true
+}


### PR DESCRIPTION
### Enhanced Debugging with CloudFront Standard Logging

We're excited to introduce a significant update to the AWS Educate TPET backend. This release focuses on enhancing your debugging capabilities with the integration of CloudFront standard logging.

#### Key Improvements:
- **CloudFront Standard Logging**: Now enabled for improved debugging, allowing detailed insights into your API traffic.
- **Error Resolution**: Fixed the 502 error by correcting the Host header forwarding, ensuring smoother API operations.
