### PR TITLE
[SCRUM-105] List files - 500 error none type object is not subscriptable

### DIFF
--- a/src/auth_service/is_logged_in/lambda_function.py
+++ b/src/auth_service/is_logged_in/lambda_function.py
@@ -22,7 +22,7 @@ def lambda_handler(event, context):
     """
 
     # Get accessToken from the Authorization header
-    authorization_header = event.get("headers", {}).get("Authorization", "")
+    authorization_header = event.get("headers", {}).get("authorization", "")
     logger.info("Received Authorization header: %s", authorization_header)
 
     if not authorization_header.startswith("Bearer "):

--- a/src/auth_service/terraform/api_gateway.tf
+++ b/src/auth_service/terraform/api_gateway.tf
@@ -35,7 +35,7 @@ module "api_gateway" {
   cors_configuration = {
     allow_headers     = ["content-type", "x-amz-date", "authorization", "x-api-key", "x-amz-security-token", "x-amz-user-agent"]
     allow_methods     = ["*"]
-    allow_origins     = ["http://localhost:3000", "http://localhost:5500", "https://aws-educate.tw", "https://tpet.aws-educate.tw", "https://vercel.app"]
+    allow_origins     = ["http://localhost:3000", "http://localhost:5500", "https://*"]
     allow_credentials = true
   }
 
@@ -111,15 +111,6 @@ module "api_gateway" {
         type                   = "AWS_PROXY"
         payload_format_version = "1.0"
         timeout_milliseconds   = 29000
-      }
-    }
-
-
-
-    "$default" = {
-      integration = {
-        uri                  = module.login_lambda.lambda_function_arn
-        passthrough_behavior = "WHEN_NO_MATCH"
       }
     }
   }

--- a/src/campaign_service/terraform/api_gateway.tf
+++ b/src/campaign_service/terraform/api_gateway.tf
@@ -35,7 +35,7 @@ module "api_gateway" {
   cors_configuration = {
     allow_headers     = ["content-type", "x-amz-date", "authorization", "x-api-key", "x-amz-security-token", "x-amz-user-agent"]
     allow_methods     = ["*"]
-    allow_origins     = ["http://localhost:3000", "http://localhost:5500", "https://aws-educate.tw", "https://tpet.aws-educate.tw", "https://vercel.app"]
+    allow_origins     = ["http://localhost:3000", "http://localhost:5500", "https://*"]
     allow_credentials = true
   }
 
@@ -62,15 +62,6 @@ module "api_gateway" {
         type                   = "AWS_PROXY"
         payload_format_version = "1.0"
         timeout_milliseconds   = 29000
-      }
-    }
-
-
-
-    "$default" = {
-      integration = {
-        uri                  = module.create_campaign_lambda.lambda_function_arn
-        passthrough_behavior = "WHEN_NO_MATCH"
       }
     }
   }

--- a/src/email_service/terraform/api_gateway.tf
+++ b/src/email_service/terraform/api_gateway.tf
@@ -35,7 +35,7 @@ module "api_gateway" {
   cors_configuration = {
     allow_headers     = ["content-type", "x-amz-date", "authorization", "x-api-key", "x-amz-security-token", "x-amz-user-agent"]
     allow_methods     = ["*"]
-    allow_origins     = ["http://localhost:3000", "http://localhost:5500", "https://aws-educate.tw", "https://tpet.aws-educate.tw", "https://vercel.app"]
+    allow_origins     = ["http://localhost:3000", "http://localhost:5500", "https://*"]
     allow_credentials = true
   }
 
@@ -62,14 +62,6 @@ module "api_gateway" {
         type                   = "AWS_PROXY"
         payload_format_version = "1.0"
         timeout_milliseconds   = 29000
-      }
-    }
-
-
-
-    "$default" = {
-      integration = {
-        uri = module.send_email_lambda.lambda_function_arn
       }
     }
   }

--- a/src/file_service/terraform/api_gateway.tf
+++ b/src/file_service/terraform/api_gateway.tf
@@ -41,7 +41,7 @@ module "api_gateway" {
   cors_configuration = {
     allow_headers     = ["content-type", "x-amz-date", "authorization", "x-api-key", "x-amz-security-token", "x-amz-user-agent"]
     allow_methods     = ["*"]
-    allow_origins     = ["http://localhost:3000", "http://localhost:5500", "https://aws-educate.tw", "https://tpet.aws-educate.tw", "https://vercel.app"]
+    allow_origins     = ["http://localhost:3000", "http://localhost:5500", "https://*"]
     allow_credentials = true
   }
 
@@ -117,15 +117,6 @@ module "api_gateway" {
         type                   = "AWS_PROXY"
         payload_format_version = "1.0"
         timeout_milliseconds   = 29000
-      }
-    }
-
-
-
-    "$default" = {
-      integration = {
-        uri                  = module.get_file_lambda.lambda_function_arn
-        passthrough_behavior = "WHEN_NO_MATCH"
       }
     }
   }


### PR DESCRIPTION
### Summary of Pull Request #43: [SCRUM-105] List files - 500 error none type object is not subscriptable

**Issue:** A 500 error occurs when listing files due to a NoneType object being unsubscriptable.

**Changes:**
1. Fixed the issue with the Authorization header not being retrieved due to a lowercase header key in the event.
2. Removed the `$default` route and updated CORS allowed origins.
3. Updated CORS configurations across all services and removed the `$default` route.

[SCRUM-105]: https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ