### PR TITLE
[SCRUM-155] EventBridge Scheduler invoke Lambda Service Account JWT Token 

### DIFF
--- a/.github/workflows/auth_service.yaml
+++ b/.github/workflows/auth_service.yaml
@@ -82,10 +82,15 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const MAX_COMMENT_LENGTH = 65536; // GitHub API comment length limit
+            const MAX_COMMENT_LENGTH = 65536;
+            const MAX_OUTPUT_LENGTH = 10000; // Limit the output length to avoid argument list too long error
+
+            const truncateOutput = (output, maxLength) => {
+              if (output.length <= maxLength) return output;
+              return output.substring(0, maxLength) + '\n... (Output truncated due to length)';
+            };
 
             const createSummary = (stdout) => {
-              // Check for success or failure keywords
               const isSuccess = stdout.includes('Apply complete!') || 
                               stdout.includes('Successfully configured');
               const hasErrors = stdout.includes('Error:') || 
@@ -94,7 +99,7 @@ jobs:
               if (hasErrors) {
                 return '❌ Deployment encountered errors. Please check the workflow logs for details.';
               } else if (isSuccess) {
-                return '✅ Deployment completed successfully! The details are too long to display here.';
+                return '✅ Deployment completed successfully!';
               } else {
                 return '⚠️ Deployment status unclear. Please check the workflow logs for details.';
               }
@@ -111,21 +116,15 @@ jobs:
             });
 
             let output = `#### Terraform Apply Results 🌟\n`;
-            const applyOutput = `${{ steps.apply.outputs.stdout }}`;
+            const applyOutput = truncateOutput(`${{ steps.apply.outputs.stdout }}`, MAX_OUTPUT_LENGTH);
 
-            if (applyOutput.length > MAX_COMMENT_LENGTH - 500) { // Reserve space for other text
-              output += createSummary(applyOutput);
-              output += '\n\n> [!NOTE]\n';
-              output += '> The complete output was too long to display here.\n';
-              output += '> You can find the full logs in the Actions tab.\n';
-            } else {
-              output += `Preview environment has been deployed. You can now test your changes.\n\n`;
-              output += `<details><summary>Show Actual Apply</summary>\n\n`;
-              output += `\`\`\`\n${applyOutput}\n\`\`\`\n\n`;
-              output += `</details>\n`;
-            }
-
-            output += `\n*Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+            output += createSummary(applyOutput);
+            output += '\n\n<details><summary>Show Output (Truncated)</summary>\n\n';
+            output += '```\n' + applyOutput + '\n```\n\n';
+            output += '</details>\n\n';
+            output += '> [!NOTE]\n';
+            output += '> The output might be truncated. Check the Actions tab for complete logs.\n\n';
+            output += `*Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
 
             if (botComment) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/auth_service.yaml
+++ b/.github/workflows/auth_service.yaml
@@ -77,34 +77,9 @@ jobs:
 
       - uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
-        env:
-          APPLY: "terraform\n${{ steps.apply.outputs.stdout }}"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const MAX_COMMENT_LENGTH = 65536;
-            const MAX_OUTPUT_LENGTH = 10000; // Limit the output length to avoid argument list too long error
-
-            const truncateOutput = (output, maxLength) => {
-              if (output.length <= maxLength) return output;
-              return output.substring(0, maxLength) + '\n... (Output truncated due to length)';
-            };
-
-            const createSummary = (stdout) => {
-              const isSuccess = stdout.includes('Apply complete!') || 
-                              stdout.includes('Successfully configured');
-              const hasErrors = stdout.includes('Error:') || 
-                              stdout.includes('Failed to');
-              
-              if (hasErrors) {
-                return '❌ Deployment encountered errors. Please check the workflow logs for details.';
-              } else if (isSuccess) {
-                return '✅ Deployment completed successfully!';
-              } else {
-                return '⚠️ Deployment status unclear. Please check the workflow logs for details.';
-              }
-            };
-
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -115,16 +90,16 @@ jobs:
               return comment.user.type === 'Bot' && comment.body.includes('Terraform Apply Results');
             });
 
-            let output = `#### Terraform Apply Results 🌟\n`;
-            const applyOutput = truncateOutput(`${{ steps.apply.outputs.stdout }}`, MAX_OUTPUT_LENGTH);
+            const exitCode = '${{ steps.apply.outcome }}' === 'success' ? 0 : 1;
 
-            output += createSummary(applyOutput);
-            output += '\n\n<details><summary>Show Output (Truncated)</summary>\n\n';
-            output += '```\n' + applyOutput + '\n```\n\n';
-            output += '</details>\n\n';
-            output += '> [!NOTE]\n';
-            output += '> The output might be truncated. Check the Actions tab for complete logs.\n\n';
-            output += `*Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+            let output = `#### Terraform Apply Results 🌟\n`;
+            if (exitCode === 0) {
+              output += '✅ Deployment completed successfully!\n';
+            } else {
+              output += '❌ Deployment encountered errors. Please check the workflow logs for details.\n';
+            }
+
+            output += `\n*Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
 
             if (botComment) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/auth_service.yaml
+++ b/.github/workflows/auth_service.yaml
@@ -16,6 +16,15 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TF_DIR: ./src/auth_service/terraform
+  GREP_FILTER: >-
+    grep -v -E '^[[:space:]]*(module\.|random_|aws_).*: (Creating|Creation complete|Still creating|Modifications complete|Destroying|Destruction complete|Reading\.\.\.|Plan:|Read complete after)' |
+    grep -v -E '^\[.*\][[:space:]]*module\..*$' |
+    grep -v '^[0-9]+[[:space:]]' |
+    grep -v 'Creation complete after' |
+    grep -v 'Still creating\.\.\.' |
+    grep -v ': Reading\.\.\.' |
+    grep -v ': Read complete' |
+    grep -v 'Refreshing state\.\.\.'
 
 permissions:
   contents: write
@@ -48,30 +57,21 @@ jobs:
       - name: Terraform Destroy (Cleanup)
         id: destroy
         run: |
-          terraform destroy -auto-approve -var-file='preview.tfvars' 2>&1 | \
-          grep -v -E '^[[:space:]]*(module\.|random_|aws_).*: (Creating|Creation complete|Still creating|Modifications complete|Destroying|Destruction complete|Reading\.\.\.)' | \
-          grep -v -E '^\[.*\][[:space:]]*module\..*$' | \
-          grep -v '^[0-9]+[[:space:]]'
+          terraform destroy -auto-approve -var-file='preview.tfvars' 2>&1 | ${{ env.GREP_FILTER }}
         working-directory: ${{ env.TF_DIR }}
         continue-on-error: true
 
       - name: Terraform Plan
         id: plan
         run: |
-          terraform plan -var-file='preview.tfvars' 2>&1 | \
-          grep -v -E '^[[:space:]]*(module\.|random_|aws_).*: (Creating|Creation complete|Still creating|Modifications complete|Destroying|Destruction complete|Reading\.\.\.|Plan:)' | \
-          grep -v -E '^\[.*\][[:space:]]*module\..*$' | \
-          grep -v '^[0-9]+[[:space:]]'
+          terraform plan -var-file='preview.tfvars' 2>&1 | ${{ env.GREP_FILTER }}
         working-directory: ${{ env.TF_DIR }}
         continue-on-error: true
 
       - name: Terraform Apply
         id: apply
         run: |
-          terraform apply -var-file='preview.tfvars' -auto-approve 2>&1 | \
-          grep -v -E '^[[:space:]]*(module\.|random_|aws_).*: (Creating|Creation complete|Still creating|Modifications complete|Destroying|Destruction complete|Reading\.\.\.)' | \
-          grep -v -E '^\[.*\][[:space:]]*module\..*$' | \
-          grep -v '^[0-9]+[[:space:]]'
+          terraform apply -var-file='preview.tfvars' -auto-approve 2>&1 | ${{ env.GREP_FILTER }}
         working-directory: ${{ env.TF_DIR }}
         continue-on-error: true
 
@@ -142,10 +142,7 @@ jobs:
 
       - name: Terraform Destroy
         run: |
-          terraform destroy -auto-approve -var-file='preview.tfvars' 2>&1 | \
-          grep -v -E '^[[:space:]]*(module\.|random_|aws_).*: (Creating|Creation complete|Still creating|Modifications complete|Destroying|Destruction complete|Reading\.\.\.)' | \
-          grep -v -E '^\[.*\][[:space:]]*module\..*$' | \
-          grep -v '^[0-9]+[[:space:]]'
+          terraform destroy -auto-approve -var-file='preview.tfvars' 2>&1 | ${{ env.GREP_FILTER }}
         working-directory: ${{ env.TF_DIR }}
 
   deploy:
@@ -185,29 +182,20 @@ jobs:
       - name: Terraform Destroy (Cleanup)
         id: destroy
         run: |
-          terraform destroy -auto-approve -var-file='${{ env.TF_VARS_FILE }}' 2>&1 | \
-          grep -v -E '^[[:space:]]*(module\.|random_|aws_).*: (Creating|Creation complete|Still creating|Modifications complete|Destroying|Destruction complete|Reading\.\.\.)' | \
-          grep -v -E '^\[.*\][[:space:]]*module\..*$' | \
-          grep -v '^[0-9]+[[:space:]]'
+          terraform destroy -auto-approve -var-file='${{ env.TF_VARS_FILE }}' 2>&1 | ${{ env.GREP_FILTER }}
         working-directory: ${{ env.TF_DIR }}
         continue-on-error: true
 
       - name: Terraform Plan
         id: plan
         run: |
-          terraform plan -var-file='${{ env.TF_VARS_FILE }}' 2>&1 | \
-          grep -v -E '^[[:space:]]*(module\.|random_|aws_).*: (Creating|Creation complete|Still creating|Modifications complete|Destroying|Destruction complete|Reading\.\.\.|Plan:)' | \
-          grep -v -E '^\[.*\][[:space:]]*module\..*$' | \
-          grep -v '^[0-9]+[[:space:]]'
+          terraform plan -var-file='${{ env.TF_VARS_FILE }}' 2>&1 | ${{ env.GREP_FILTER }}
         working-directory: ${{ env.TF_DIR }}
         continue-on-error: true
 
       - name: Terraform Apply
         id: apply
         run: |
-          terraform apply -var-file='${{ env.TF_VARS_FILE }}' -auto-approve 2>&1 | \
-          grep -v -E '^[[:space:]]*(module\.|random_|aws_).*: (Creating|Creation complete|Still creating|Modifications complete|Destroying|Destruction complete|Reading\.\.\.)' | \
-          grep -v -E '^\[.*\][[:space:]]*module\..*$' | \
-          grep -v '^[0-9]+[[:space:]]'
+          terraform apply -var-file='${{ env.TF_VARS_FILE }}' -auto-approve 2>&1 | ${{ env.GREP_FILTER }}
         working-directory: ${{ env.TF_DIR }}
         continue-on-error: true

--- a/.github/workflows/auth_service.yaml
+++ b/.github/workflows/auth_service.yaml
@@ -82,6 +82,24 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const MAX_COMMENT_LENGTH = 65536; // GitHub API comment length limit
+
+            const createSummary = (stdout) => {
+              // Check for success or failure keywords
+              const isSuccess = stdout.includes('Apply complete!') || 
+                              stdout.includes('Successfully configured');
+              const hasErrors = stdout.includes('Error:') || 
+                              stdout.includes('Failed to');
+              
+              if (hasErrors) {
+                return '❌ Deployment encountered errors. Please check the workflow logs for details.';
+              } else if (isSuccess) {
+                return '✅ Deployment completed successfully! The details are too long to display here.';
+              } else {
+                return '⚠️ Deployment status unclear. Please check the workflow logs for details.';
+              }
+            };
+
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -92,18 +110,22 @@ jobs:
               return comment.user.type === 'Bot' && comment.body.includes('Terraform Apply Results');
             });
 
-            const output = `#### Terraform Apply Results 🌟
-            Preview environment has been deployed. You can now test your changes.
+            let output = `#### Terraform Apply Results 🌟\n`;
+            const applyOutput = `${{ steps.apply.outputs.stdout }}`;
 
-            <details><summary>Show Actual Apply</summary>
+            if (applyOutput.length > MAX_COMMENT_LENGTH - 500) { // Reserve space for other text
+              output += createSummary(applyOutput);
+              output += '\n\n> [!NOTE]\n';
+              output += '> The complete output was too long to display here.\n';
+              output += '> You can find the full logs in the Actions tab.\n';
+            } else {
+              output += `Preview environment has been deployed. You can now test your changes.\n\n`;
+              output += `<details><summary>Show Actual Apply</summary>\n\n`;
+              output += `\`\`\`\n${applyOutput}\n\`\`\`\n\n`;
+              output += `</details>\n`;
+            }
 
-            \`\`\`\n
-            ${{ steps.apply.outputs.stdout }}
-            \`\`\`
-
-            </details>
-
-            *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+            output += `\n*Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
 
             if (botComment) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/auth_service.yaml
+++ b/.github/workflows/auth_service.yaml
@@ -47,19 +47,31 @@ jobs:
 
       - name: Terraform Destroy (Cleanup)
         id: destroy
-        run: terraform destroy -auto-approve -var-file='preview.tfvars'
+        run: |
+          terraform destroy -auto-approve -var-file='preview.tfvars' 2>&1 | \
+          grep -v -E '^[[:space:]]*(module\.|random_|aws_).*: (Creating|Creation complete|Still creating|Modifications complete|Destroying|Destruction complete|Reading\.\.\.)' | \
+          grep -v -E '^\[.*\][[:space:]]*module\..*$' | \
+          grep -v '^[0-9]+[[:space:]]'
         working-directory: ${{ env.TF_DIR }}
         continue-on-error: true
 
       - name: Terraform Plan
         id: plan
-        run: terraform plan -var-file='preview.tfvars'
+        run: |
+          terraform plan -var-file='preview.tfvars' 2>&1 | \
+          grep -v -E '^[[:space:]]*(module\.|random_|aws_).*: (Creating|Creation complete|Still creating|Modifications complete|Destroying|Destruction complete|Reading\.\.\.|Plan:)' | \
+          grep -v -E '^\[.*\][[:space:]]*module\..*$' | \
+          grep -v '^[0-9]+[[:space:]]'
         working-directory: ${{ env.TF_DIR }}
         continue-on-error: true
 
       - name: Terraform Apply
         id: apply
-        run: terraform apply -var-file='preview.tfvars' -auto-approve
+        run: |
+          terraform apply -var-file='preview.tfvars' -auto-approve 2>&1 | \
+          grep -v -E '^[[:space:]]*(module\.|random_|aws_).*: (Creating|Creation complete|Still creating|Modifications complete|Destroying|Destruction complete|Reading\.\.\.)' | \
+          grep -v -E '^\[.*\][[:space:]]*module\..*$' | \
+          grep -v '^[0-9]+[[:space:]]'
         working-directory: ${{ env.TF_DIR }}
         continue-on-error: true
 
@@ -129,7 +141,11 @@ jobs:
         working-directory: ${{ env.TF_DIR }}
 
       - name: Terraform Destroy
-        run: terraform destroy -auto-approve -var-file='preview.tfvars'
+        run: |
+          terraform destroy -auto-approve -var-file='preview.tfvars' 2>&1 | \
+          grep -v -E '^[[:space:]]*(module\.|random_|aws_).*: (Creating|Creation complete|Still creating|Modifications complete|Destroying|Destruction complete|Reading\.\.\.)' | \
+          grep -v -E '^\[.*\][[:space:]]*module\..*$' | \
+          grep -v '^[0-9]+[[:space:]]'
         working-directory: ${{ env.TF_DIR }}
 
   deploy:
@@ -168,18 +184,30 @@ jobs:
 
       - name: Terraform Destroy (Cleanup)
         id: destroy
-        run: terraform destroy -auto-approve -var-file='${{ env.TF_VARS_FILE }}'
+        run: |
+          terraform destroy -auto-approve -var-file='${{ env.TF_VARS_FILE }}' 2>&1 | \
+          grep -v -E '^[[:space:]]*(module\.|random_|aws_).*: (Creating|Creation complete|Still creating|Modifications complete|Destroying|Destruction complete|Reading\.\.\.)' | \
+          grep -v -E '^\[.*\][[:space:]]*module\..*$' | \
+          grep -v '^[0-9]+[[:space:]]'
         working-directory: ${{ env.TF_DIR }}
         continue-on-error: true
 
       - name: Terraform Plan
         id: plan
-        run: terraform plan -var-file='${{ env.TF_VARS_FILE }}' -out=tfplan
+        run: |
+          terraform plan -var-file='${{ env.TF_VARS_FILE }}' 2>&1 | \
+          grep -v -E '^[[:space:]]*(module\.|random_|aws_).*: (Creating|Creation complete|Still creating|Modifications complete|Destroying|Destruction complete|Reading\.\.\.|Plan:)' | \
+          grep -v -E '^\[.*\][[:space:]]*module\..*$' | \
+          grep -v '^[0-9]+[[:space:]]'
         working-directory: ${{ env.TF_DIR }}
         continue-on-error: true
 
       - name: Terraform Apply
         id: apply
-        run: terraform apply -var-file='${{ env.TF_VARS_FILE }}' -auto-approve
+        run: |
+          terraform apply -var-file='${{ env.TF_VARS_FILE }}' -auto-approve 2>&1 | \
+          grep -v -E '^[[:space:]]*(module\.|random_|aws_).*: (Creating|Creation complete|Still creating|Modifications complete|Destroying|Destruction complete|Reading\.\.\.)' | \
+          grep -v -E '^\[.*\][[:space:]]*module\..*$' | \
+          grep -v '^[0-9]+[[:space:]]'
         working-directory: ${{ env.TF_DIR }}
         continue-on-error: true

--- a/src/auth_service/refresh_service_accounts_token/Dockerfile
+++ b/src/auth_service/refresh_service_accounts_token/Dockerfile
@@ -1,0 +1,11 @@
+FROM public.ecr.aws/lambda/python:3.11
+
+# Install dependencies
+COPY requirements.txt /var/task/
+RUN pip install -r /var/task/requirements.txt
+
+# Copy function code
+COPY . /var/task/
+
+# Set the command to run the Lambda function
+CMD ["lambda_function.lambda_handler"]

--- a/src/auth_service/refresh_service_accounts_token/lambda_function.py
+++ b/src/auth_service/refresh_service_accounts_token/lambda_function.py
@@ -66,7 +66,7 @@ def refresh_service_account_access_token(service_account: str) -> Dict:
 
         # Prepare login payload with complete API Gateway format
         login_payload = {
-            "headers": {"origin": "*", "Content-Type": "application/json"},
+            "headers": {"Content-Type": "application/json"},
             "httpMethod": "POST",
             "body": json.dumps({"account": service_account, "password": password}),
             "requestContext": {"http": {"method": "POST"}},

--- a/src/auth_service/refresh_service_accounts_token/lambda_function.py
+++ b/src/auth_service/refresh_service_accounts_token/lambda_function.py
@@ -1,0 +1,147 @@
+import json
+import logging
+import os
+
+import boto3
+from botocore.exceptions import ClientError
+
+# Initialize logger
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# Initialize AWS clients
+secrets_client = boto3.client("secretsmanager")
+lambda_client = boto3.client("lambda")
+
+# Environment variables
+AUTH_LOGIN_FUNCTION = os.getenv("AUTH_LOGIN_FUNCTION")
+SERVICE_ACCOUNT_SECRET_NAME = os.getenv("SERVICE_ACCOUNT_SECRET_NAME")
+
+
+def get_service_account_password():
+    """
+    Get service account password from AWS Secrets Manager.
+
+    Returns:
+        str: The password stored in Secrets Manager.
+
+    Raises:
+        ClientError: If there's an error retrieving the secret.
+    """
+    try:
+        response = secrets_client.get_secret_value(SecretId=SERVICE_ACCOUNT_SECRET_NAME)
+        secret_data = json.loads(response["SecretString"])
+        return secret_data["password"]
+    except ClientError as e:
+        logger.error("Failed to get password from Secrets Manager: %s", e)
+        raise
+
+
+def get_access_token(password):
+    """
+    Invoke auth login lambda to get access token.
+
+    Args:
+        password (str): Service account password.
+
+    Returns:
+        str: The access token from login response.
+
+    Raises:
+        ClientError: If Lambda invocation fails.
+        ValueError: If the login response is invalid.
+    """
+    try:
+        payload = {"body": json.dumps({"account": "surveycake", "password": password})}
+
+        response = lambda_client.invoke(
+            FunctionName=AUTH_LOGIN_FUNCTION,
+            InvocationType="RequestResponse",
+            Payload=json.dumps(payload),
+        )
+
+        response_payload = json.loads(response["Payload"].read().decode())
+
+        if response_payload["statusCode"] != 200:
+            logger.error(
+                "Login failed with status %d: %s",
+                response_payload["statusCode"],
+                response_payload["body"],
+            )
+            raise ValueError("Login request failed")
+
+        body = json.loads(response_payload["body"])
+        return body["access_token"]
+
+    except ClientError as e:
+        logger.error("Lambda invocation failed: %s", e)
+        raise
+
+
+def update_access_token(access_token):
+    """
+    Update access token in Secrets Manager.
+
+    Args:
+        access_token (str): New access token to store.
+
+    Raises:
+        ClientError: If there's an error updating the secret.
+    """
+    try:
+        secret_data = {"access_token": access_token, "account": "surveycake"}
+
+        secrets_client.update_secret(
+            SecretId=SERVICE_ACCOUNT_SECRET_NAME, SecretString=json.dumps(secret_data)
+        )
+
+    except ClientError as e:
+        logger.error("Failed to update token in Secrets Manager: %s", e)
+        raise
+
+
+def lambda_handler(event, context):
+    """
+    AWS Lambda handler function to refresh service account access token.
+
+    Args:
+        event (dict): Event data (unused).
+        context (dict): Context data (unused).
+
+    Returns:
+        dict: Response object with status code and body.
+    """
+    try:
+        # Get password from Secrets Manager
+        password = get_service_account_password()
+
+        # Get new access token via Lambda invocation
+        access_token = get_access_token(password)
+
+        # Update access token in Secrets Manager
+        update_access_token(access_token)
+
+        return {
+            "statusCode": 200,
+            "body": json.dumps({"message": "Token refresh successful"}),
+        }
+
+    except ClientError as e:
+        logger.error("AWS service error: %s", e)
+        return {
+            "statusCode": 500,
+            "body": json.dumps(
+                {"message": "Failed to interact with AWS services", "error": str(e)}
+            ),
+        }
+    except ValueError as e:
+        logger.error("Value error: %s", e)
+        return {"statusCode": 400, "body": json.dumps({"message": str(e)})}
+    except Exception as e:
+        logger.error("Unexpected error: %s", e)
+        return {
+            "statusCode": 500,
+            "body": json.dumps(
+                {"message": "An unexpected error occurred", "error": str(e)}
+            ),
+        }

--- a/src/auth_service/refresh_service_accounts_token/lambda_function.py
+++ b/src/auth_service/refresh_service_accounts_token/lambda_function.py
@@ -46,24 +46,30 @@ def refresh_service_account_access_token(service_account: str) -> Dict:
         service_account (str): Name of the service account to refresh token for
 
     Returns:
-        dict: Result of the refresh operation
+        dict: Result of the refresh operation containing:
+            - service_account: Name of the service account
+            - status: 'success' or 'failed'
+            - message: Success message or error details
 
     Raises:
         ClientError: If AWS service interaction fails
-        ValueError: If the refresh operation fails
+        ValueError: If the login response is invalid
     """
     try:
         logger.info("Starting token refresh for service account: %s", service_account)
 
-        # Get password
+        # Retrieve service account password from Secrets Manager
         password_response = secrets_client.get_secret_value(
             SecretId=get_secret_path(service_account, "password")
         )
         password = json.loads(password_response["SecretString"])["password"]
 
-        # Get new token
+        # Prepare login payload with complete API Gateway format
         login_payload = {
-            "body": json.dumps({"account": service_account, "password": password})
+            "headers": {"origin": "*", "Content-Type": "application/json"},
+            "httpMethod": "POST",
+            "body": json.dumps({"account": service_account, "password": password}),
+            "requestContext": {"http": {"method": "POST"}},
         }
 
         login_response = lambda_client.invoke(
@@ -72,14 +78,36 @@ def refresh_service_account_access_token(service_account: str) -> Dict:
             Payload=json.dumps(login_payload),
         )
 
+        # Check for Lambda execution errors
+        if "FunctionError" in login_response:
+            error_detail = login_response.get("Payload").read().decode()
+            raise ValueError(f"Lambda execution failed: {error_detail}")
+
         login_result = json.loads(login_response["Payload"].read().decode())
 
-        if login_result["statusCode"] != 200:
-            raise ValueError(f"Login failed: {login_result['body']}")
+        # Parse login Lambda response
+        try:
+            if isinstance(login_result, dict):
+                # Handle API Gateway response format
+                if "statusCode" in login_result:
+                    if login_result["statusCode"] != 200:
+                        raise ValueError(
+                            f"Login failed with status {login_result['statusCode']}: {login_result.get('body')}"
+                        )
+                    response_body = json.loads(login_result["body"])
+                    access_token = response_body["access_token"]
+                # Handle direct Lambda response format
+                elif "access_token" in login_result:
+                    access_token = login_result["access_token"]
+                else:
+                    raise ValueError(f"Invalid response format: {login_result}")
+            else:
+                raise ValueError(f"Unexpected response type: {type(login_result)}")
 
-        access_token = json.loads(login_result["body"])["access_token"]
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Failed to parse login response: {str(e)}")
 
-        # Update access token
+        # Store the new access token in Secrets Manager
         secret_data = {"account": service_account, "access_token": access_token}
 
         secrets_client.update_secret(
@@ -104,23 +132,28 @@ def refresh_service_account_access_token(service_account: str) -> Dict:
 def lambda_handler(event, context):
     """
     AWS Lambda handler function to refresh access tokens for all service accounts.
+    This function iterates through all configured service accounts and refreshes their access tokens.
 
     Args:
-        event (dict): Event data (unused)
-        context (dict): Context data (unused)
+        event (dict): Event data passed to the Lambda function (unused)
+        context (dict): Runtime information provided by AWS Lambda (unused)
 
     Returns:
-        dict: Response object with status code and body containing results for all service accounts
+        dict: Response object containing:
+            - statusCode: 200 for success, 500 if any refresh operation failed
+            - body: JSON string containing detailed results and summary
     """
     results = []
     has_failures = False
 
+    # Process each service account
     for service_account in SERVICE_ACCOUNTS:
         result = refresh_service_account_access_token(service_account)
         results.append(result)
         if result["status"] == "failed":
             has_failures = True
 
+    # Prepare response with summary
     response_body = {
         "results": results,
         "summary": {

--- a/src/auth_service/terraform/.terraform.lock.hcl
+++ b/src/auth_service/terraform/.terraform.lock.hcl
@@ -3,8 +3,9 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.54.1"
-  constraints = "~> 5.54.0"
+  constraints = ">= 4.22.0, >= 4.40.0, >= 5.32.0, >= 5.37.0, ~> 5.54.0"
   hashes = [
+    "h1:+aq386lQCaPX7wR6EPf3PPZvCiI6dRwnjb1wR6lNa8E=",
     "h1:h6AA+TgBpDNQXFcLi4xKYiDbn94Dfhz7lt8Q8x8CEI8=",
     "zh:37c09b9a0a0a2f7854fe52c6adb15f71593810b458a8283ed71d68036af7ba3a",
     "zh:42fe11d87723d4e43b9c6224ae6bacdcb53faee8abc58f0fc625a161d1f71cb1",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/external" {
   constraints = ">= 1.0.0"
   hashes = [
     "h1:/x65slrvO8YG5MKxE2DaU5udEbUxBu3BgEiO7EEM9bQ=",
+    "h1:gShzO1rJtADK9tDZMvMgjciVAzsBh39LNjtThCwX1Hg=",
     "zh:03d81462f9578ec91ce8e26f887e34151eda0e100f57e9772dbea86363588239",
     "zh:37ec2a20f6a3ec3a0fd95d3f3de26da6cb9534b30488bc45723e118a0911c0d8",
     "zh:4eb5b119179539f2749ce9de0e1b9629d025990f062f4f4dddc161562bb89d37",
@@ -46,8 +48,9 @@ provider "registry.terraform.io/hashicorp/external" {
 
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.5.1"
-  constraints = "~> 2.5.1"
+  constraints = ">= 1.0.0, ~> 2.5.1"
   hashes = [
+    "h1:/GAVA/xheGQcbOZEq0qxANOg+KVLCA7Wv8qluxhTjhU=",
     "h1:Np4kERf9SMrqUi7DJ1rK3soMK14k49nfgE7l/ipQ5xw=",
     "zh:0af29ce2b7b5712319bf6424cb58d13b852bf9a777011a545fac99c7fdcdf561",
     "zh:126063ea0d79dad1f68fa4e4d556793c0108ce278034f101d1dbbb2463924561",
@@ -68,6 +71,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.2"
   constraints = ">= 2.0.0"
   hashes = [
+    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
     "h1:m467k2tZ9cdFFgHW7LPBK2GLPH43LC6wc3ppxr8yvoE=",
     "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
     "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
@@ -88,6 +92,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version = "3.6.2"
   hashes = [
     "h1:5lstwe/L8AZS/CP0lil2nPvmbbjAu8kCaU/ogSGNbxk=",
+    "h1:VavG5unYCa3SYISMKF9pzc3718M0bhPlcbUZZGl7wuo=",
     "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
     "zh:1bcd2d8161e89e39886119965ef0f37fcce2da9c1aca34263dd3002ba05fcb53",
     "zh:37c75d15e9514556a5f4ed02e1548aaa95c0ecd6ff9af1119ac905144c70c114",
@@ -105,9 +110,10 @@ provider "registry.terraform.io/hashicorp/random" {
 
 provider "registry.terraform.io/kreuzwerker/docker" {
   version     = "3.0.2"
-  constraints = "~> 3.0.2"
+  constraints = ">= 3.0.0, ~> 3.0.2"
   hashes = [
     "h1:DcRxJArfX6EiATluWeCBW7HoD6usz9fMoTK2U3dmyPk=",
+    "h1:XjdpVL61KtTsuPE8swok3GY8A+Bu3TZs8T2DOEpyiXo=",
     "zh:15b0a2b2b563d8d40f62f83057d91acb02cd0096f207488d8b4298a59203d64f",
     "zh:23d919de139f7cd5ebfd2ff1b94e6d9913f0977fcfc2ca02e1573be53e269f95",
     "zh:38081b3fe317c7e9555b2aaad325ad3fa516a886d2dfa8605ae6a809c1072138",

--- a/src/auth_service/terraform/eventbridge.tf
+++ b/src/auth_service/terraform/eventbridge.tf
@@ -1,0 +1,41 @@
+# Create EventBridge scheduler group
+resource "aws_scheduler_schedule_group" "service_group" {
+  name = "${var.environment}-${var.service_underscore}-schedule_group"
+
+  tags = {
+    Service = var.service_underscore
+  }
+}
+
+# Create EventBridge scheduler
+resource "aws_scheduler_schedule" "refresh_service_accounts_token" {
+  name        = "${var.environment}-${var.service_underscore}-refresh_service_accounts_token"
+  group_name  = aws_scheduler_schedule_group.service_group.name
+  description = "Schedule to refresh service accounts token every 23 hours"
+
+  flexible_time_window {
+    mode = "OFF" # Run exactly at scheduled time
+  }
+
+  schedule_expression = "rate(23 hours)"
+
+  target {
+    arn      = module.refresh_service_accounts_token_lambda.lambda_function_arn
+    role_arn = aws_iam_role.refresh_service_accounts_token_scheduler_role.arn
+    retry_policy {
+      maximum_retry_attempts = 0 # Explicitly disable retries
+    }
+  }
+}
+
+
+# Outputs
+output "scheduler_group_arn" {
+  value       = aws_scheduler_schedule_group.service_group.arn
+  description = "ARN of the EventBridge scheduler group"
+}
+
+output "scheduler_arn" {
+  value       = aws_scheduler_schedule.refresh_service_accounts_token.arn
+  description = "ARN of the EventBridge scheduler for token refresh"
+}

--- a/src/auth_service/terraform/iam.tf
+++ b/src/auth_service/terraform/iam.tf
@@ -1,0 +1,55 @@
+# Create IAM role specifically for refreshing service account tokens
+resource "aws_iam_role" "refresh_service_accounts_token_scheduler_role" {
+  name = "${var.environment}-${var.service_underscore}-refresh_service_accounts_token-sche-${random_string.this.result}" # 64 characters max
+
+  description = "Role for EventBridge scheduler to trigger refresh service accounts token lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "scheduler.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" : data.aws_caller_identity.this.account_id
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Service = var.service_underscore
+  }
+}
+
+# Create specific IAM policy for invoking the refresh token lambda
+resource "aws_iam_role_policy" "refresh_service_accounts_token_scheduler_policy" {
+  name = "${var.environment}-${var.service_underscore}-invoke_refresh_service_accounts_token_lambda-${random_string.this.result}"
+  role = aws_iam_role.refresh_service_accounts_token_scheduler_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "lambda:InvokeFunction"
+        ]
+        Resource = [
+          module.refresh_service_accounts_token_lambda.lambda_function_arn
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/Environment" : var.environment,
+            "aws:ResourceTag/Service" : var.service_underscore
+          }
+        }
+      }
+    ]
+  })
+}

--- a/src/auth_service/terraform/lambda.tf
+++ b/src/auth_service/terraform/lambda.tf
@@ -607,9 +607,9 @@ module "refresh_service_accounts_token_lambda" {
   }
 
   allowed_triggers = {
-    AllowExecutionFromAPIGateway = {
-      service    = "apigateway"
-      source_arn = "${module.api_gateway.api_execution_arn}/*/*"
+    AllowExecutionFromEventBridgeScheduler = {
+      service    = "scheduler"
+      source_arn = aws_scheduler_schedule.refresh_service_accounts_token.arn
     }
   }
 

--- a/src/auth_service/terraform/lambda.tf
+++ b/src/auth_service/terraform/lambda.tf
@@ -632,8 +632,8 @@ module "refresh_service_accounts_token_lambda" {
         "secretsmanager:UpdateSecret"
       ],
       resources = [
-        "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.this.account_id}:secret:aws-educate-tpet/${var.environment}/service-accounts/*/password",
-        "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.this.account_id}:secret:aws-educate-tpet/${var.environment}/service-accounts/*/access-token"
+        "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.this.account_id}:secret:aws-educate-tpet/${var.environment}/service-accounts/*/password-*",
+        "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.this.account_id}:secret:aws-educate-tpet/${var.environment}/service-accounts/*/access-token-*"
       ]
     },
 

--- a/src/auth_service/terraform/lambda.tf
+++ b/src/auth_service/terraform/lambda.tf
@@ -603,7 +603,7 @@ module "refresh_service_accounts_token_lambda" {
     "ENVIRONMENT"        = var.environment,
     "SERVICE"            = var.service_underscore
     "COGNITO_CLIENT_ID"  = data.aws_ssm_parameter.aws_educate_tpet_cognito_client_id.value
-    "LOGIN_FUNCTION_ARN" = module.login_lambda.lambda_function_invoke_arn
+    "LOGIN_FUNCTION_ARN" = module.login_lambda.lambda_function_arn
   }
 
   allowed_triggers = {
@@ -644,7 +644,7 @@ module "refresh_service_accounts_token_lambda" {
         "lambda:InvokeFunction"
       ],
       resources = [
-        module.login_lambda.lambda_function_invoke_arn
+        module.login_lambda.lambda_function_arn
       ]
     }
   }

--- a/src/auth_service/terraform/lambda.tf
+++ b/src/auth_service/terraform/lambda.tf
@@ -20,18 +20,19 @@ resource "random_string" "this" {
 }
 
 locals {
-  source_path                                     = "${path.module}/.."
-  login_function_name_and_ecr_repo_name           = "${var.environment}-${var.service_underscore}-login-${random_string.this.result}"
-  change_password_function_name_and_ecr_repo_name = "${var.environment}-${var.service_underscore}-change_password-${random_string.this.result}"
-  get_user_function_name_and_ecr_repo_name        = "${var.environment}-${var.service_underscore}-get_user-${random_string.this.result}"
-  get_me_function_name_and_ecr_repo_name          = "${var.environment}-${var.service_underscore}-get_me-${random_string.this.result}"
-  is_logged_in_function_name_and_ecr_repo_name    = "${var.environment}-${var.service_underscore}-is_logged_in-${random_string.this.result}"
-  path_include                                    = ["**"]
-  path_exclude                                    = ["**/__pycache__/**"]
-  files_include                                   = setunion([for f in local.path_include : fileset(local.source_path, f)]...)
-  files_exclude                                   = setunion([for f in local.path_exclude : fileset(local.source_path, f)]...)
-  files                                           = sort(setsubtract(local.files_include, local.files_exclude))
-  dir_sha                                         = sha1(join("", [for f in local.files : filesha1("${local.source_path}/${f}")]))
+  source_path                                                    = "${path.module}/.."
+  login_function_name_and_ecr_repo_name                          = "${var.environment}-${var.service_underscore}-login-${random_string.this.result}"
+  change_password_function_name_and_ecr_repo_name                = "${var.environment}-${var.service_underscore}-change_password-${random_string.this.result}"
+  get_user_function_name_and_ecr_repo_name                       = "${var.environment}-${var.service_underscore}-get_user-${random_string.this.result}"
+  get_me_function_name_and_ecr_repo_name                         = "${var.environment}-${var.service_underscore}-get_me-${random_string.this.result}"
+  is_logged_in_function_name_and_ecr_repo_name                   = "${var.environment}-${var.service_underscore}-is_logged_in-${random_string.this.result}"
+  refresh_service_accounts_token_function_name_and_ecr_repo_name = "${var.environment}-${var.service_underscore}-refresh_service_accounts_token-${random_string.this.result}"
+  path_include                                                   = ["**"]
+  path_exclude                                                   = ["**/__pycache__/**"]
+  files_include                                                  = setunion([for f in local.path_include : fileset(local.source_path, f)]...)
+  files_exclude                                                  = setunion([for f in local.path_exclude : fileset(local.source_path, f)]...)
+  files                                                          = sort(setsubtract(local.files_include, local.files_exclude))
+  dir_sha                                                        = sha1(join("", [for f in local.files : filesha1("${local.source_path}/${f}")]))
 }
 
 provider "docker" {
@@ -139,7 +140,7 @@ module "login_docker_image" {
     ]
   })
 
-  # docker_campaign_path = "${local.source_path}/path/to/Dockercampaign" # set `docker_campaign_path` If your Dockercampaign is not in `source_path`
+  # docker_file_path = "${local.source_path}/path/to/Dockerfile" # set `docker_file_path` If your Dockerfile is not in `source_path`
   source_path = "${local.source_path}/login/" # Remember to change
   triggers = {
     dir_sha = local.dir_sha
@@ -245,7 +246,7 @@ module "change_password_docker_image" {
     ]
   })
 
-  # docker_campaign_path = "${local.source_path}/path/to/Dockercampaign" # set `docker_campaign_path` If your Dockercampaign is not in `source_path`
+  # docker_file_path = "${local.source_path}/path/to/Dockerfile" # set `docker_file_path` If your Dockerfile is not in `source_path`
   source_path = "${local.source_path}/change_password/" # Remember to change
   triggers = {
     dir_sha = local.dir_sha
@@ -351,7 +352,7 @@ module "get_user_docker_image" {
     ]
   })
 
-  # docker_campaign_path = "${local.source_path}/path/to/Dockercampaign" # set `docker_campaign_path` If your Dockercampaign is not in `source_path`
+  # docker_file_path = "${local.source_path}/path/to/Dockerfile" # set `docker_file_path` If your Dockerfile is not in `source_path`
   source_path = "${local.source_path}/get_user/" # Remember to change
   triggers = {
     dir_sha = local.dir_sha
@@ -456,7 +457,7 @@ module "get_me_docker_image" {
     ]
   })
 
-  # docker_campaign_path = "${local.source_path}/path/to/Dockercampaign" # set `docker_campaign_path` If your Dockercampaign is not in `source_path`
+  # docker_file_path = "${local.source_path}/path/to/Dockerfile" # set `docker_file_path` If your Dockerfile is not in `source_path`
   source_path = "${local.source_path}/get_me/" # Remember to change
   triggers = {
     dir_sha = local.dir_sha
@@ -561,8 +562,122 @@ module "is_logged_in_docker_image" {
     ]
   })
 
-  # docker_campaign_path = "${local.source_path}/path/to/Dockercampaign" # set `docker_campaign_path` If your Dockercampaign is not in `source_path`
+  # docker_file_path = "${local.source_path}/path/to/Dockerfile" # set `docker_file_path` If your Dockerfile is not in `source_path`
   source_path = "${local.source_path}/is_logged_in/" # Remember to change
+  triggers = {
+    dir_sha = local.dir_sha
+  }
+
+}
+
+
+
+#################################################
+#################################################
+#################################################
+# EventBridge Scheduler Invoke periodically #####
+#################################################
+#################################################
+#################################################
+
+module "refresh_service_accounts_token_lambda" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "7.7.0"
+
+  function_name  = local.refresh_service_accounts_token_function_name_and_ecr_repo_name
+  description    = "AWS Educate TPET ${var.service_hyphen} in ${var.environment}: EventBridge Scheduler Invoke periodically"
+  create_package = false
+  timeout        = 300
+
+  ##################
+  # Container Image
+  ##################
+  package_type  = "Image"
+  architectures = ["x86_64"] # or ["arm64"]
+  image_uri     = module.refresh_service_accounts_token_docker_image.image_uri
+
+  publish = true # Whether to publish creation/change as new Lambda Function Version.
+
+
+  environment_variables = {
+    "ENVIRONMENT"        = var.environment,
+    "SERVICE"            = var.service_underscore
+    "COGNITO_CLIENT_ID"  = data.aws_ssm_parameter.aws_educate_tpet_cognito_client_id.value
+    "LOGIN_FUNCTION_ARN" = module.login_lambda.lambda_function_invoke_arn
+  }
+
+  allowed_triggers = {
+    AllowExecutionFromAPIGateway = {
+      service    = "apigateway"
+      source_arn = "${module.api_gateway.api_execution_arn}/*/*"
+    }
+  }
+
+  tags = {
+    "Terraform"   = "true",
+    "Environment" = var.environment,
+    "Service"     = var.service_underscore
+  }
+  ######################
+  # Additional policies
+  ######################
+
+  attach_policy_statements = true
+  policy_statements = {
+    # Secrets Manager permissions
+    secrets_manager = {
+      effect = "Allow",
+      actions = [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:UpdateSecret"
+      ],
+      resources = [
+        "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.this.account_id}:secret:aws-educate-tpet/${var.environment}/service-accounts/*/password",
+        "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.this.account_id}:secret:aws-educate-tpet/${var.environment}/service-accounts/*/access-token"
+      ]
+    },
+
+    # Allow invoke login lambda
+    invoke_login_lambda = {
+      effect = "Allow",
+      actions = [
+        "lambda:InvokeFunction"
+      ],
+      resources = [
+        module.login_lambda.lambda_function_invoke_arn
+      ]
+    }
+  }
+}
+
+module "refresh_service_accounts_token_docker_image" {
+  source  = "terraform-aws-modules/lambda/aws//modules/docker-build"
+  version = "7.7.0"
+
+  create_ecr_repo      = true
+  keep_remotely        = true
+  use_image_tag        = false
+  image_tag_mutability = "MUTABLE"
+  ecr_repo             = local.refresh_service_accounts_token_function_name_and_ecr_repo_name
+  ecr_repo_lifecycle_policy = jsonencode({
+    "rules" : [
+      {
+        "rulePriority" : 1,
+        "description" : "Keep only the last 10 images",
+        "selection" : {
+          "tagStatus" : "any",
+          "countType" : "imageCountMoreThan",
+          "countNumber" : 10
+        },
+        "action" : {
+          "type" : "expire"
+        }
+      }
+    ]
+  })
+
+  # docker_file_path = "${local.source_path}/path/to/Dockerfile" # set `docker_file_path` If your Dockerfile is not in `source_path`
+  source_path = "${local.source_path}/refresh_service_accounts_token/" # Remember to change
   triggers = {
     dir_sha = local.dir_sha
   }

--- a/src/auth_service/terraform/secrets_manager.tf
+++ b/src/auth_service/terraform/secrets_manager.tf
@@ -1,0 +1,65 @@
+# Secret for service account access token
+resource "aws_secretsmanager_secret" "surveycake_service_account_access_token" {
+  name        = "aws-educate-tpet/${var.environment}/service-accounts/surveycake/access-token"
+  description = "Access token for AWS Eudcate TPET ${var.environment} SurveyCake service account"
+
+  tags = {
+    Service = var.service_underscore
+  }
+
+  # Resource Policy
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowWebhookServiceToReadSecret"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:PrincipalTag/Service" : "webhook",
+            "aws:PrincipalTag/Environment" : var.environment
+          }
+        }
+      },
+      {
+        Sid    = "AllowTokenRefreshServiceToManageSecret"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:UpdateSecret"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:PrincipalTag/Service" : "token-refresh",
+            "aws:PrincipalTag/Environment" : var.environment
+          }
+        }
+      }
+    ]
+  })
+}
+
+# Store initial access token (empty)
+resource "aws_secretsmanager_secret_version" "surveycake_access_token" {
+  secret_id = aws_secretsmanager_secret.surveycake_service_account_access_token.id
+  secret_string = jsonencode({
+    account      = "surveycake"
+    access_token = ""
+  })
+}
+
+# Output
+output "surveycake_access_token_secret_name" {
+  value = aws_secretsmanager_secret.surveycake_service_account_access_token.name
+}

--- a/src/auth_service/terraform/secrets_manager.tf
+++ b/src/auth_service/terraform/secrets_manager.tf
@@ -23,13 +23,13 @@ resource "aws_secretsmanager_secret" "surveycake_service_account_access_token" {
         Resource = "*"
         Condition = {
           StringEquals = {
-            "aws:PrincipalTag/Service" : "webhook",
+            "aws:PrincipalTag/Service" : "webhook_service",
             "aws:PrincipalTag/Environment" : var.environment
           }
         }
       },
       {
-        Sid    = "AllowTokenRefreshServiceToManageSecret"
+        Sid    = "AllowTokenRefreshFunctionToManageSecret"
         Effect = "Allow"
         Principal = {
           Service = "lambda.amazonaws.com"
@@ -41,7 +41,7 @@ resource "aws_secretsmanager_secret" "surveycake_service_account_access_token" {
         Resource = "*"
         Condition = {
           StringEquals = {
-            "aws:PrincipalTag/Service" : "token-refresh",
+            "aws:PrincipalTag/Service" : "auth_service",
             "aws:PrincipalTag/Environment" : var.environment
           }
         }


### PR DESCRIPTION
## Description
<!--
請提供這個 PR 的簡要描述：
- 這個 PR 解決了什麼問題？
- 為什麼需要這個變更？
- 如何實現的？
-->

自動排程刷新 surveycake service account 的 Access token 然後儲存至 Secrets Manager。

本 Feature 有技術債，已將技術債紀錄於 [SCRUM-167](https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-167?atlOrigin=eyJpIjoiNjBmYjhkN2ZiYzg5NGFmMTk0MTI5YTIyNWY4NmRlNzYiLCJwIjoiaiJ9)

## Type of Change
<!--
請勾選適用的變更類型（可多選）
-->
- [ ] 🐛 Bug Fix（修復 bug）
- [x] ✨ New Feature（新功能）
- [ ] 💄 UI/UX（介面或使用者體驗優化）
- [ ] 🔨 Refactor（程式碼重構）
- [ ] 📝 Documentation（文件更新）
- [ ] 🔧 Configuration（配置變更）
- [ ] 🚀 Performance（效能優化）
- [ ] ✅ Test（測試相關）
- [ ] 🔒 Security（安全性相關）

## Related Issues
<!--
請列出相關的 issue 編號
例如：Closes #123, Relates to #456
-->
[SCRUM-155](https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-155?atlOrigin=eyJpIjoiYmNkOTYyYzdiOTNlNGRjZTk0Y2Q0ZDliNzUzYjM3YTMiLCJwIjoiaiJ9)

## Testing
<!--
請描述如何測試這些變更：
- 已執行哪些測試？
- 如何驗證這些變更？
- 是否需要特別的測試步驟？
-->

### 以下為測試步驟

1. 切換至區域 us-west-2，至 Secrets Manager 頁面，然後找到 
**aws-educate-tpet/local-dev/service-accounts/surveycake/access-token** ，並點擊 **Retrieve secret value**

  <img width="1329" alt="image" src="https://github.com/user-attachments/assets/a579d00b-cc83-49bf-aed3-407bc09517ee">

2. 點擊 **Edit**，並將 `access_token` 設為空白
  <img width="1319" alt="image" src="https://github.com/user-attachments/assets/ae7eeadd-b27c-4548-9e5b-fdcfeb54eb2d">

3. 至 EventBridge Scheduler 頁面，勾選 `local-dev-auth_service-refresh_service_accounts_token` 然後修改 `rate`，例如 1 minutes
  <img width="1877" alt="image" src="https://github.com/user-attachments/assets/344d34ee-7a1a-4e13-aaac-44535607f0ce">
  
  <img width="1020" alt="image" src="https://github.com/user-attachments/assets/3dd35989-fe64-46a2-9511-ddc31048061f">

4. 等待 1 分鐘後，回到 Secrets Manager 頁面，再次 **Retrieve secret value**，將看到全新的 access_token
5. 您亦可至 Lambda Function `local-dev-auth_service-login-ynad` 檢查 CloudWatch Logs 會發現 surveycake 的登入記錄
6. 將 EventBridge Scheduler 的 `rate` 調整回 `23 hours`


### 測試結果


<img width="1374" alt="image" src="https://github.com/user-attachments/assets/22f6ba5b-75b5-41b2-a079-4db65e45e48b">


## Screenshots/Videos
<!--
如果是 UI 變更，請提供截圖或影片
-->


## Checklist
<!--
在提交 PR 前，請確認以下項目：
-->
- [x] 我已經測試過這些變更
- [ ] 我已經更新相關文件
- [x] 我的程式碼遵循專案的程式碼規範
- [x] 我已經處理所有的 console warnings/errors
- [x] 我已經移除所有的 console.log
- [ ] 我已經新增必要的測試案例
- [ ] 所有現有的測試都能通過

## Additional Notes
<!--
其他補充說明或注意事項
-->
> [!NOTE]
> 本 Feature 有技術債，已將技術債紀錄於 [SCRUM-167](https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-167?atlOrigin=eyJpIjoiNjBmYjhkN2ZiYzg5NGFmMTk0MTI5YTIyNWY4NmRlNzYiLCJwIjoiaiJ9)

> [!CAUTION]
> 若您有測試此 PR，測試完畢務必記得將 Scheduler rate 調整回 **23 hours**，如下圖
>
>  <img width="661" alt="image" src="https://github.com/user-attachments/assets/df9bc938-cd01-448f-9064-d7ace9035618">



[SCRUM-167]: https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCRUM-155]: https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCRUM-167]: https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ