### PR TITLE
[SCRUM-184] Enable deletion protection for the DynamoDB tables in the dev environment

### DIFF
--- a/src/auth_service/terraform/dev.tfvars
+++ b/src/auth_service/terraform/dev.tfvars
@@ -4,4 +4,4 @@ service_underscore                            = "auth_service"
 service_hyphen                                = "auth-service"
 dynamodb_table                                = "user"
 enable_pitr                                   = false
-enable_deletion_protection_for_dynamodb_table = false
+enable_deletion_protection_for_dynamodb_table = true

--- a/src/campaign_service/terraform/dev.tfvars
+++ b/src/campaign_service/terraform/dev.tfvars
@@ -4,4 +4,4 @@ service_underscore                            = "campaign_service"
 service_hyphen                                = "campaign-service"
 dynamodb_table                                = "campaign"
 enable_pitr                                   = false
-enable_deletion_protection_for_dynamodb_table = false
+enable_deletion_protection_for_dynamodb_table = true

--- a/src/email_service/terraform/dev.tfvars
+++ b/src/email_service/terraform/dev.tfvars
@@ -6,4 +6,4 @@ dynamodb_table                                = "email"
 run_dynamodb_table                            = "run"
 pagination_state_dynamodb_table               = "email_service_pagination_state"
 enable_pitr                                   = false
-enable_deletion_protection_for_dynamodb_table = false
+enable_deletion_protection_for_dynamodb_table = true

--- a/src/file_service/terraform/dev.tfvars
+++ b/src/file_service/terraform/dev.tfvars
@@ -4,4 +4,4 @@ service_underscore                            = "file_service"
 service_hyphen                                = "file-service"
 dynamodb_table                                = "file"
 enable_pitr                                   = false
-enable_deletion_protection_for_dynamodb_table = false
+enable_deletion_protection_for_dynamodb_table = true


### PR DESCRIPTION
## Description
<!--
請提供這個 PR 的簡要描述：
- 這個 PR 解決了什麼問題？
- 為什麼需要這個變更？
- 如何實現的？
-->

Enable deletion protection for the DynamoDB tables in the dev environment. This will prevent the items in the DynamoDB tables from being deleted during the deployment of a new version.

## Type of Change
<!--
請勾選適用的變更類型（可多選）
-->
- [ ] 🐛 Bug Fix（修復 bug）
- [ ] ✨ New Feature（新功能）
- [ ] 💄 UI/UX（介面或使用者體驗優化）
- [ ] 🔨 Refactor（程式碼重構）
- [ ] 📝 Documentation（文件更新）
- [x] 🔧 Configuration（配置變更）
- [ ] 🚀 Performance（效能優化）
- [ ] ✅ Test（測試相關）
- [ ] 🔒 Security（安全性相關）

## Related Issues
<!--
請列出相關的 issue 編號
例如：Closes #123, Relates to #456
-->

[SCRUM-184](https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-184)

## Testing
<!--
請描述如何測試這些變更：
- 已執行哪些測試？
- 如何驗證這些變更？
- 是否需要特別的測試步驟？
-->

N/A




## Screenshots/Videos
<!--
如果是 UI 變更，請提供截圖或影片
-->

N/A

## Checklist
<!--
在提交 PR 前，請確認以下項目：
-->
- [ ] 我已經測試過這些變更
- [ ] 我已經更新相關文件
- [x] 我的程式碼遵循專案的程式碼規範
- [ ] 我已經處理所有的 console warnings/errors
- [ ] 我已經移除所有的 console.log
- [ ] 我已經新增必要的測試案例
- [ ] 所有現有的測試都能通過

## Additional Notes
<!--
其他補充說明或注意事項
-->

[SCRUM-184]: https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ