### PR TITLE
[SCRUM-296] add values in <env>.tfvars

### DIFF
--- a/src/email_service/terraform/dev.tfvars
+++ b/src/email_service/terraform/dev.tfvars
@@ -7,4 +7,5 @@ run_dynamodb_table                            = "run"
 pagination_state_dynamodb_table               = "email_service_pagination_state"
 enable_pitr                                   = true
 enable_deletion_protection_for_dynamodb_table = true
-lambda_architecture = "x86_64"
+lambda_architecture                           = "x86_64"
+database_name                                 = "email_service_db"

--- a/src/email_service/terraform/preview.tfvars
+++ b/src/email_service/terraform/preview.tfvars
@@ -7,4 +7,5 @@ run_dynamodb_table                            = "run"
 pagination_state_dynamodb_table               = "email_service_pagination_state"
 enable_pitr                                   = false
 enable_deletion_protection_for_dynamodb_table = true
-lambda_architecture = "x86_64"
+lambda_architecture                           = "x86_64"
+database_name                                 = "email_service_db"

--- a/src/email_service/terraform/prod.tfvars
+++ b/src/email_service/terraform/prod.tfvars
@@ -7,4 +7,5 @@ run_dynamodb_table                            = "run"
 pagination_state_dynamodb_table               = "email_service_pagination_state"
 enable_pitr                                   = true
 enable_deletion_protection_for_dynamodb_table = true
-lambda_architecture = "x86_64"
+lambda_architecture                           = "x86_64"
+database_name                                 = "email_service_db"


### PR DESCRIPTION
This pull request introduces a new `database_name` variable to the Terraform configuration files for the email service across all environments (dev, preview, and prod). This change ensures consistent database naming in the infrastructure setup.

### Infrastructure updates:

* Added `database_name = "email_service_db"` to the Terraform configuration for the `dev` environment in `src/email_service/terraform/dev.tfvars`.
* Added `database_name = "email_service_db"` to the Terraform configuration for the `preview` environment in `src/email_service/terraform/preview.tfvars`.
* Added `database_name = "email_service_db"` to the Terraform configuration for the `prod` environment in `src/email_service/terraform/prod.tfvars`.