### PR TITLE
TPET release v2.1.0 (fix tf required version)

### DIFF
--- a/src/campaign_service/terraform/versions.tf
+++ b/src/campaign_service/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8.0"
+  required_version = "~> 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/modules/public_s3/versions.tf
+++ b/terraform/modules/public_s3/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8.0"
+  required_version = "~> 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
This pull request updates the required Terraform version in two locations to ensure compatibility with Terraform 1.9.x. No other changes are included.

- Updated the `required_version` in `src/campaign_service/terraform/versions.tf` from `~> 1.8.0` to `~> 1.9.0` to require Terraform 1.9.x.
- Updated the `required_version` in `terraform/modules/public_s3/versions.tf` from `~> 1.8.0` to `~> 1.9.0` to require Terraform 1.9.x.