### PR TITLE
fix(rsvp_service/create_campaign): set is_active to true by default (…

### DIFF
--- a/src/rsvp_service/create_campaign/lambda_function.py
+++ b/src/rsvp_service/create_campaign/lambda_function.py
@@ -88,7 +88,7 @@ def lambda_handler(event: dict, context: object) -> dict:
         "campaign_end_time": body.get("campaign_end_time", ""),
         "campaign_location": body.get("campaign_location", ""),
         "created_at": now,
-        "is_active": False,
+        "is_active": True,
     }
 
     try:


### PR DESCRIPTION
## Description
This PR updates the RSVP service campaign creation logic so newly created campaigns are active by default.

Previously, `create_campaign` stored `"is_active": False` in the campaign record. As a result, a newly created campaign could immediately fail the `verify_campaign` check and be treated as inactive.

This change updates the default value to `"is_active": True` so newly created campaigns can pass verification right after creation.

## Type of Change
- [x] 🐛 Bug Fix (fixes an issue)
- [ ] ✨ New Feature (introduces a new feature)
- [ ] 💄 UI/UX (improves interface or user experience)
- [ ] 🔨 Refactor (code refactoring)
- [ ] 📝 Documentation (updates documentation)
- [ ] 🔧 Configuration (changes configuration)
- [ ] 🚀 Performance (improves performance)
- [ ] ✅ Test (related to tests)
- [ ] 🔒 Security (addresses security concerns)

## Related Issues
Relates to SCRUM-589

## Testing
- Updated the default `is_active` value in `create_campaign` from `False` to `True`
- Verified the campaign record now stores `is_active: true` when created
- Verified this aligns with `verify_campaign`, which rejects campaigns when `is_active` is `False`

## Screenshots/Videos
N/A

## Checklist
- [ ] I have tested these changes.
- [ ] I have updated the relevant documentation.
- [x] My code adheres to the project’s code standards.
- [x] I have addressed all console warnings/errors.
- [x] I have removed all `console.log` or `print()` statements.
- [ ] I have added necessary test cases.
- [ ] All existing tests pass.

## Additional Notes
This PR only changes the default activation state for newly created campaigns. It does not change the `verify_campaign` response format or DynamoDB query logic.
