### PR TITLE
feat(rsvp): add last edited time to get_rsvp_status response

### DIFF
--- a/src/rsvp_service/get_rsvp_status/lambda_function.py
+++ b/src/rsvp_service/get_rsvp_status/lambda_function.py
@@ -101,6 +101,7 @@ def lambda_handler(event, context):
             "status": "SUCCESS",
             "rsvp_status": user_item.get("rsvp_status", RsvpStatus.PENDING),
             "participant_name": user_item.get("name", token_name),
+            "last_edited_time": user_item.get("updated_at"),
             "campaign_name": camp_master_item.get("campaign_name", ""),
             "campaign_start_time": camp_master_item.get("campaign_start_time", ""),
             "campaign_location": camp_master_item.get("campaign_location", ""),


### PR DESCRIPTION
## Description
This PR updates the RSVP status API response to include the participant's last edited time and aligns the local development Lambda architecture setting for `rsvp_service`.

Changes made:
- Added `last_edited_time` to the `get_rsvp_status` API response using the participant record's `updated_at` field

## Type of Change
- [ ] 🐛 Bug Fix (fixes an issue)
- [x] ✨ New Feature (introduces a new feature)
- [ ] 💄 UI/UX (improves interface or user experience)
- [ ] 🔨 Refactor (code refactoring)
- [ ] 📝 Documentation (updates documentation)
- [x] 🔧 Configuration (changes configuration)
- [ ] 🚀 Performance (improves performance)
- [ ] ✅ Test (related to tests)
- [ ] 🔒 Security (addresses security concerns)

## Related Issues
[SCRUM-619](https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-619?atlOrigin=eyJpIjoiYzY5MGI4NDM1YzNjNGU1OWFhZTk1OTRmMTRmMGI5M2MiLCJwIjoiaiJ9)

## Testing
- Verified the code change in `get_rsvp_status` returns `last_edited_time` from the participant `updated_at` field
- No automated tests were added or run in this change

## Screenshots/Videos
N/A

## Checklist
- [ ] I have tested these changes.
- [ ] I have updated the relevant documentation.
- [x] My code adheres to the project’s code standards.
- [x] I have addressed all console warnings/errors.
- [x] I have removed all `console.log` or `print()` statements.
- [ ] I have added necessary test cases.
- [ ] All existing tests pass.


[SCRUM-619]: https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ