### PR TITLE
fis: Remove destroy step from email service deploy workflow(SCRUM-626)

### DIFF
--- a/.github/workflows/email_service.yaml
+++ b/.github/workflows/email_service.yaml
@@ -675,14 +675,6 @@ jobs:
             echo "::notice::Database migration completed successfully for ${{ env.ENVIRONMENT }}."
           fi
 
-      # Terraform Apply (AFTER DB Migration to ensure schema is ready for new Lambda code)
-      - name: Terraform Destroy (Cleanup)
-        id: destroy
-        run: |
-          set -o pipefail
-          terraform destroy -auto-approve -var-file='${{ env.TF_VARS_FILE }}' 2>&1 | ${{ env.GREP_FILTER }}
-        working-directory: ${{ env.TF_DIR }}
-
       - name: Terraform Plan
         id: plan
         run: |

--- a/src/email_service/validate_input/rsvp_service.py
+++ b/src/email_service/validate_input/rsvp_service.py
@@ -11,6 +11,7 @@ logger.setLevel(logging.INFO)
 class RSVPService:
     def __init__(self):
         self.environment = os.environ.get("ENVIRONMENT")
+        # Internal RSVP service endpoint is environment-scoped.
         self.base_url = (
             f"https://{self.environment}-rsvp-service-internal-api-tpet.aws-educate.tw"
         )


### PR DESCRIPTION
## Description
This PR removes the `terraform destroy` step from the `email_service` deploy workflow for target environments.

The current deploy job attempted to destroy infrastructure before running `terraform plan` and `terraform apply`. That causes deployments to fail in `dev` because the email service DynamoDB tables and Aurora cluster are protected against deletion. This change keeps the normal deployment flow as `plan` + `apply` only, which matches the intended behavior for persistent environments.

A small non-functional comment change was also added under `src/email_service/**` to trigger the email service workflow.

## Type of Change
- [x] 🔧 Configuration (changes configuration)
- [x] 📝 Documentation (updates documentation)

## Related Issues
N/A

## Testing
- Verified the workflow definition no longer includes the `terraform destroy` step in the `deploy` job.
- Confirmed the change only affects the email service deployment workflow and leaves the remaining steps intact.
- Did not run Terraform or GitHub Actions locally.

## Screenshots/Videos
N/A

## Checklist
- [ ] I have tested these changes.
- [ ] I have updated the relevant documentation.
- [x] My code adheres to the project’s code standards.
- [x] I have addressed all console warnings/errors.
- [x] I have removed all `console.log` or `print()` statements.
- [ ] I have added necessary test cases.
- [ ] All existing tests pass.

## Additional Notes
This change is intended to prevent `dev` and `prod` deployments from attempting to delete protected RDS and DynamoDB resources. If cleanup is needed for ephemeral environments such as `preview` or `local-dev`, it should be handled in a separate environment-specific workflow rather than the main deploy job.