### PR TITLE
[SCRUM-630] Set response headers in Get rsvp status API

### DIFF
--- a/src/rsvp_service/get_rsvp_status/lambda_function.py
+++ b/src/rsvp_service/get_rsvp_status/lambda_function.py
@@ -43,6 +43,7 @@ def lambda_handler(event, context):
         if len(parts) < 2:
             return {
                 "statusCode": 400,
+                "headers": {"Content-Type": "application/json"},
                 "body": json.dumps({"message": "Invalid ID format"}),
             }
         path_run_id, path_participant_id = parts[0], parts[1]
@@ -87,6 +88,7 @@ def lambda_handler(event, context):
             )
             return {
                 "statusCode": 404,
+                "headers": {"Content-Type": "application/json"},
                 "body": json.dumps(
                     {"status": "error", "message": "Activity not found"}
                 ),
@@ -109,18 +111,24 @@ def lambda_handler(event, context):
             "is_registration_closed": is_registration_closed,
         }
 
-        return {"statusCode": 200, "body": json.dumps(response_data)}
+        return {
+            "statusCode": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps(response_data),
+        }
 
     except AuthenticationError as e:
         logger.warning("Authentication failed: %s", e)
         return {
             "statusCode": 401,
+            "headers": {"Content-Type": "application/json"},
             "body": json.dumps({"code": "INVALID_TOKEN", "message": str(e)}),
         }
     except Exception as e:
         logger.error("System Error: %s", e)
         return {
             "statusCode": 500,
+            "headers": {"Content-Type": "application/json"},
             "body": json.dumps(
                 {"code": "INTERNAL_ERROR", "message": "Internal server error"}
             ),


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 🎉
-->

<!-- markdownlint-disable MD041 -->
## Description
<!--
Provide a brief description of this PR:
- What issue does this PR address?
- Why is this change necessary?
- How was it implemented?
-->

### Background

While fixing the regression test failures in [SCRUM-582](https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-582?atlOrigin=eyJpIjoiYzgyNWU1MmVmZjExNDE4MzljNGViMjRlYWNkMzIxMTIiLCJwIjoiaiJ9), we found that the `Get rsvp status` API does not set a `Content-Type` header (all the other RSVP APIs set it in their response `headers`). As a result it returns `text/plain; charset=utf-8` instead of `application/json`, which caused one of the regression test assertions to fail.

<img width="1470" height="586" alt="Screenshot 2026-06-14 at 00 01 14" src="https://github.com/user-attachments/assets/73a0f190-3cce-4080-a712-f7b28b6cd6d6" />

### Changes

Added `"headers": {"Content-Type": "application/json"}` to every JSON response in `get_rsvp_status` (status 200 / 400 / 401 / 404 / 500), so the endpoint correctly declares its content type and stays consistent with the other RSVP endpoints.

## Type of Change
<!--
Select the type(s) of changes made (you can select multiple):
-->
- [x] 🐛 Bug Fix (fixes an issue)
- [ ] ✨ New Feature (introduces a new feature)
- [ ] 💄 UI/UX (improves interface or user experience)
- [ ] 🔨 Refactor (code refactoring)
- [ ] 📝 Documentation (updates documentation)
- [ ] 🔧 Configuration (changes configuration)
- [ ] 🚀 Performance (improves performance)
- [ ] ✅ Test (related to tests)
- [ ] 🔒 Security (addresses security concerns)

## Related Issues
<!--
List related issue numbers or links:
Example: Closes SCRUM-123, Relates to SCRUM-456
-->

[SCRUM-630](https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-630?atlOrigin=eyJpIjoiZWE4OTExNTZkODgyNGUzOWFiYTJjMDU1ZTdkMzRjN2IiLCJwIjoiaiJ9)

## Testing
<!--
Describe how these changes were tested:
- What tests were performed?
- How were these changes verified?
- Are there any specific test steps required?
-->

Tested `Get rsvp status` API in Postman on both local-dev and preview. It now returns Content-Type: `application/json` with  a `200` response successfully.

## Screenshots/Videos
<!--
Provide screenshots or videos to demonstrate the changes (if applicable).
-->

<img width="1470" height="923" alt="Screenshot 2026-06-14 at 00 35 50" src="https://github.com/user-attachments/assets/55eb3502-1256-4032-9188-33b8b35ae6bf" />

<img width="1470" height="923" alt="Screenshot 2026-06-14 at 00 35 54" src="https://github.com/user-attachments/assets/e62477a4-b34e-438f-9dba-b87dde1286c6" />

<img width="1470" height="923" alt="Screenshot 2026-06-14 at 00 57 09" src="https://github.com/user-attachments/assets/0be7ede9-9bcb-4793-ab6d-8af5cf624911" />

## Checklist
<!--
Ensure the following items are checked before submitting the PR:
-->
- [x] I have tested these changes.
- [x] I have updated the relevant documentation.
- [x] My code adheres to the project’s code standards.
- [x] I have addressed all console warnings/errors.
- [x] I have removed all `console.log` or `print()` statements.
- [x] I have added necessary test cases.
- [x] All existing tests pass.

## Additional Notes
<!--
Add any other relevant notes or considerations:
-->

N/A

<!--
Reminder:
Before submitting your PR, please review the **Coding Guidelines**: https://aws-educate-tw.notion.site/TPET-Backend-Coding-Guidelines-12e6bfee681780ac89c3cf43854380d4?pvs=4
-->

<!-- markdownlint-enable MD041 -->


[SCRUM-582]: https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCRUM-630]: https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ