### PR TITLE
[SCRUM-622] refactor(auth): use Powertools secret retrieval for tokens from secrets manager

### DIFF
--- a/src/auth_service/refresh_service_accounts_token/lambda_function.py
+++ b/src/auth_service/refresh_service_accounts_token/lambda_function.py
@@ -3,6 +3,8 @@ import logging
 import os
 
 import boto3
+from aws_lambda_powertools.utilities.parameters import get_secret
+from aws_lambda_powertools.utilities.parameters.exceptions import GetParameterError
 from botocore.exceptions import ClientError
 
 # Initialize logger
@@ -59,10 +61,11 @@ def refresh_service_account_access_token(service_account: str) -> dict:
         logger.info("Starting token refresh for service account: %s", service_account)
 
         # Retrieve service account password from Secrets Manager
-        password_response = secrets_client.get_secret_value(
-            SecretId=get_secret_path(service_account, "password")
+        password_secret = get_secret(
+            get_secret_path(service_account, "password"),
+            transform="json",
         )
-        password = json.loads(password_response["SecretString"])["password"]
+        password = password_secret["password"]
 
         # Prepare login payload with complete API Gateway format
         login_payload = {
@@ -122,7 +125,7 @@ def refresh_service_account_access_token(service_account: str) -> dict:
             "message": "Token refresh successful",
         }
 
-    except (ClientError, ValueError) as e:
+    except (ClientError, GetParameterError, ValueError) as e:
         logger.error(
             "Token refresh failed for service account %s: %s", service_account, str(e)
         )

--- a/src/auth_service/refresh_service_accounts_token/requirements.txt
+++ b/src/auth_service/refresh_service_accounts_token/requirements.txt
@@ -1,0 +1,1 @@
+aws-lambda-powertools==3.30.0

--- a/src/rsvp_service/get_rsvp_status/jwt_util.py
+++ b/src/rsvp_service/get_rsvp_status/jwt_util.py
@@ -1,7 +1,11 @@
+import logging
 import os
 
 import jwt
 from aws_lambda_powertools.utilities.parameters import get_secret
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class AuthenticationError(Exception):
@@ -44,7 +48,12 @@ def _get_jwt_secret():
     if not jwt_secret_arn:
         raise RuntimeError("JWT_SECRET_ARN environment variable is not set")
 
-    secret = get_secret(jwt_secret_arn)
+    try:
+        secret = get_secret(jwt_secret_arn)
+    except Exception as e:
+        logger.exception("Failed to retrieve JWT secret: %s", e)
+        raise
+
     if not secret:
         raise RuntimeError("JWT secret is empty")
 

--- a/src/rsvp_service/get_rsvp_status/jwt_util.py
+++ b/src/rsvp_service/get_rsvp_status/jwt_util.py
@@ -1,15 +1,11 @@
 import os
 
-import boto3
 import jwt
+from aws_lambda_powertools.utilities.parameters import get_secret
 
 
 class AuthenticationError(Exception):
     pass
-
-
-_secretsmanager_client = boto3.client("secretsmanager")
-_jwt_secret_cache = None
 
 
 def _extract_token(headers):
@@ -44,19 +40,12 @@ def decode_rsvp_token(headers):
 
 
 def _get_jwt_secret():
-    global _jwt_secret_cache
-
-    if _jwt_secret_cache is not None:
-        return _jwt_secret_cache
-
     jwt_secret_arn = os.getenv("JWT_SECRET_ARN")
     if not jwt_secret_arn:
         raise RuntimeError("JWT_SECRET_ARN environment variable is not set")
 
-    response = _secretsmanager_client.get_secret_value(SecretId=jwt_secret_arn)
-    secret_string = response.get("SecretString")
-    if not secret_string:
+    secret = get_secret(jwt_secret_arn)
+    if not secret:
         raise RuntimeError("JWT secret is empty")
 
-    _jwt_secret_cache = secret_string
-    return _jwt_secret_cache
+    return secret

--- a/src/rsvp_service/get_rsvp_status/requirements.txt
+++ b/src/rsvp_service/get_rsvp_status/requirements.txt
@@ -1,1 +1,2 @@
 pyjwt==2.8.0
+aws-lambda-powertools==3.30.0

--- a/src/rsvp_service/update_rsvp/jwt_util.py
+++ b/src/rsvp_service/update_rsvp/jwt_util.py
@@ -1,7 +1,11 @@
+import logging
 import os
 
 import jwt
 from aws_lambda_powertools.utilities.parameters import get_secret
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class AuthenticationError(Exception):
@@ -44,7 +48,12 @@ def _get_jwt_secret():
     if not jwt_secret_arn:
         raise RuntimeError("JWT_SECRET_ARN environment variable is not set")
 
-    secret = get_secret(jwt_secret_arn)
+    try:
+        secret = get_secret(jwt_secret_arn)
+    except Exception as e:
+        logger.exception("Failed to retrieve JWT secret: %s", e)
+        raise
+
     if not secret:
         raise RuntimeError("JWT secret is empty")
 

--- a/src/rsvp_service/update_rsvp/jwt_util.py
+++ b/src/rsvp_service/update_rsvp/jwt_util.py
@@ -1,15 +1,11 @@
 import os
 
-import boto3
 import jwt
+from aws_lambda_powertools.utilities.parameters import get_secret
 
 
 class AuthenticationError(Exception):
     pass
-
-
-_secretsmanager_client = boto3.client("secretsmanager")
-_jwt_secret_cache = None
 
 
 def _extract_token(headers):
@@ -44,19 +40,12 @@ def decode_rsvp_token(headers):
 
 
 def _get_jwt_secret():
-    global _jwt_secret_cache
-
-    if _jwt_secret_cache is not None:
-        return _jwt_secret_cache
-
     jwt_secret_arn = os.getenv("JWT_SECRET_ARN")
     if not jwt_secret_arn:
         raise RuntimeError("JWT_SECRET_ARN environment variable is not set")
 
-    response = _secretsmanager_client.get_secret_value(SecretId=jwt_secret_arn)
-    secret_string = response.get("SecretString")
-    if not secret_string:
+    secret = get_secret(jwt_secret_arn)
+    if not secret:
         raise RuntimeError("JWT secret is empty")
 
-    _jwt_secret_cache = secret_string
-    return _jwt_secret_cache
+    return secret

--- a/src/rsvp_service/update_rsvp/requirements.txt
+++ b/src/rsvp_service/update_rsvp/requirements.txt
@@ -1,1 +1,2 @@
 pyjwt==2.8.0
+aws-lambda-powertools==3.30.0

--- a/src/webhook_service/trigger_webhook/email_service.py
+++ b/src/webhook_service/trigger_webhook/email_service.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import requests
 from config import Config
-from utils import SecretsManager
+from utils import get_access_token
 
 # Initialize logger
 logger = logging.getLogger(__name__)
@@ -16,9 +16,6 @@ RUN_TYPE = "WEBHOOK"
 
 class EmailService:
     """Class to handle email service operations"""
-
-    def __init__(self):
-        self.secrets_manager = SecretsManager()
 
     def prepare_email_body(
         self, webhook_details: dict[str, Any], recipient_email: str
@@ -49,7 +46,7 @@ class EmailService:
     def send_email(self, email_body: dict[str, Any]) -> dict[str, Any]:
         """Send an email using the send email API"""
         try:
-            access_token = self.secrets_manager.get_access_token("surveycake")
+            access_token = get_access_token("surveycake")
             logger.info("Send email API endpoint: %s", Config.SEND_EMAIL_API_ENDPOINT)
 
             response = requests.post(

--- a/src/webhook_service/trigger_webhook/requirements.txt
+++ b/src/webhook_service/trigger_webhook/requirements.txt
@@ -1,2 +1,3 @@
 requests
 pycryptodome
+aws-lambda-powertools==3.30.0

--- a/src/webhook_service/trigger_webhook/utils.py
+++ b/src/webhook_service/trigger_webhook/utils.py
@@ -5,7 +5,7 @@ This module contains utility functions that are used by the trigger_webhook modu
 import json
 from decimal import Decimal
 
-import boto3
+from aws_lambda_powertools.utilities.parameters import get_secret
 from config import Config
 from Crypto.Cipher import AES
 
@@ -19,26 +19,14 @@ class DecimalEncoder(json.JSONEncoder):
         return super().default(o)
 
 
-class SecretsManager:
-    """Class to handle the Secrets Manager operations"""
-
-    def __init__(self):
-        self.client = boto3.client("secretsmanager")
-
-    def get_secret_path(self, service_account: str, secret_type: str) -> str:
-        """Get the secret path based on the service account and secret type"""
-        return f"aws-educate-tpet/{Config.ENVIRONMENT}/service-accounts/{service_account}/{secret_type}"
-
-    def get_access_token(self, service_account: str) -> str:
-        """Get the access token from the Secrets Manager"""
-        try:
-            response = self.client.get_secret_value(
-                SecretId=self.get_secret_path(service_account, "access-token")
-            )
-            return json.loads(response["SecretString"])["access_token"]
-        except Exception as e:
-            print(f"Failed to retrieve access token: {str(e)}")
-            raise
+def get_access_token(service_account: str) -> str:
+    # force_fetch=True: access tokens are rotated by auth_service; never serve a stale cached value
+    secret = get_secret(
+        f"aws-educate-tpet/{Config.ENVIRONMENT}/service-accounts/{service_account}/access-token",
+        transform="json",
+        force_fetch=True,
+    )
+    return secret["access_token"]
 
 
 class CryptoHandler:

--- a/terraform/alert_system/auto_reenable/lambda_function.py
+++ b/terraform/alert_system/auto_reenable/lambda_function.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 
 import boto3
 from botocore.exceptions import ClientError
@@ -11,11 +10,12 @@ from utils import (
     CloudWatchAlarmState,
     IncidentState,
     build_blocks,
+    get_slack_config,
     post_thread_message,
     update_incident_message,
 )
 
-SLACK_BOT_TOKEN = os.environ["SLACK_BOT_TOKEN"]
+SLACK_BOT_TOKEN = get_slack_config()["slack_bot_token"]
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)

--- a/terraform/alert_system/auto_reenable/requirements.txt
+++ b/terraform/alert_system/auto_reenable/requirements.txt
@@ -1,1 +1,2 @@
 slack-sdk==3.19.0
+aws-lambda-powertools==3.30.0

--- a/terraform/alert_system/lambda.tf
+++ b/terraform/alert_system/lambda.tf
@@ -11,11 +11,11 @@ resource "random_string" "this" {
 }
 
 locals {
-  source_path_alert = "${path.module}/slack_alert/"
-  source_path_handler  = "${path.module}/slack_interaction_handler/"
+  source_path_alert   = "${path.module}/slack_alert/"
+  source_path_handler = "${path.module}/slack_interaction_handler/"
 
-  slack_alert_function_name_and_ecr_name     = "${var.environment}-slack-alert-${random_string.this.result}"
-  slack_handler_function_name_and_ecr_name      = "${var.environment}-slack-interaction-handler-${random_string.this.result}"
+  slack_alert_function_name_and_ecr_name   = "${var.environment}-slack-alert-${random_string.this.result}"
+  slack_handler_function_name_and_ecr_name = "${var.environment}-slack-interaction-handler-${random_string.this.result}"
 
   path_include = ["**"]
   path_exclude = [
@@ -41,11 +41,11 @@ locals {
   dir_sha_handler       = sha1(join("", [for f in local.files_handler : filesha1("${local.source_path_handler}/${f}")]))
 
   # Calculate hash for auto re-enable
-  source_path_reenable       = "${path.module}/auto_reenable/"
-  files_include_reenable     = setunion([for f in local.path_include : fileset(local.source_path_reenable, f)]...)
-  files_exclude_reenable     = setunion([for f in local.path_exclude : fileset(local.source_path_reenable, f)]...)
-  files_reenable             = sort(setsubtract(local.files_include_reenable, local.files_exclude_reenable))
-  dir_sha_reenable           = sha1(join("", [for f in local.files_reenable : filesha1("${local.source_path_reenable}/${f}")]))
+  source_path_reenable        = "${path.module}/auto_reenable/"
+  files_include_reenable      = setunion([for f in local.path_include : fileset(local.source_path_reenable, f)]...)
+  files_exclude_reenable      = setunion([for f in local.path_exclude : fileset(local.source_path_reenable, f)]...)
+  files_reenable              = sort(setsubtract(local.files_include_reenable, local.files_exclude_reenable))
+  dir_sha_reenable            = sha1(join("", [for f in local.files_reenable : filesha1("${local.source_path_reenable}/${f}")]))
   auto_reenable_function_name = "${var.environment}-auto-reenable-${random_string.this.result}"
 
 }
@@ -83,10 +83,9 @@ module "slack_alert_lambda" {
   publish = true
 
   environment_variables = {
-    ENVIRONMENT     = var.environment
-    INCIDENT_TABLE  = aws_dynamodb_table.alarm_slack_mapping.name
-    SLACK_BOT_TOKEN = local.slack_alert_config.slack_bot_token
-    SLACK_CHANNEL   = local.slack_alert_config.slack_channel
+    ENVIRONMENT                   = var.environment
+    INCIDENT_TABLE                = aws_dynamodb_table.alarm_slack_mapping.name
+    SLACK_ALERT_CONFIG_SECRET_ARN = aws_secretsmanager_secret.slack_alert_config.arn
   }
 
   allowed_triggers = {
@@ -125,6 +124,12 @@ module "slack_alert_lambda" {
       ]
       resources = ["*"]
     }
+    secrets_manager = {
+      sid       = "AllowSecretsManagerRead"
+      effect    = "Allow"
+      actions   = ["secretsmanager:GetSecretValue"]
+      resources = [aws_secretsmanager_secret.slack_alert_config.arn]
+    }
   }
 
   tags = {
@@ -149,9 +154,9 @@ module "slack_alert_docker_image" {
         rulePriority = 1
         description  = "Keep last 3 images"
         selection = {
-          tagStatus     = "any"
-          countType     = "imageCountMoreThan"
-          countNumber   = 3
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 3
         }
         action = {
           type = "expire"
@@ -199,10 +204,9 @@ module "slack_interaction_handler_lambda" {
   publish = true
 
   environment_variables = {
-    ENVIRONMENT              = var.environment
-    INCIDENT_TABLE           = aws_dynamodb_table.alarm_slack_mapping.name
-    SLACK_BOT_TOKEN          = local.slack_alert_config.slack_bot_token
-    SLACK_SIGNING_SECRET     = local.slack_alert_config.slack_signing_secret
+    ENVIRONMENT                   = var.environment
+    INCIDENT_TABLE                = aws_dynamodb_table.alarm_slack_mapping.name
+    SLACK_ALERT_CONFIG_SECRET_ARN = aws_secretsmanager_secret.slack_alert_config.arn
   }
 
   attach_policy_statements = true
@@ -226,6 +230,12 @@ module "slack_interaction_handler_lambda" {
         "cloudwatch:DescribeAlarms"
       ]
       resources = ["*"]
+    }
+    secrets_manager = {
+      sid       = "AllowSecretsManagerRead"
+      effect    = "Allow"
+      actions   = ["secretsmanager:GetSecretValue"]
+      resources = [aws_secretsmanager_secret.slack_alert_config.arn]
     }
   }
 
@@ -251,9 +261,9 @@ module "slack_interaction_handler_docker_image" {
         rulePriority = 1
         description  = "Keep last 3 images"
         selection = {
-          tagStatus     = "any"
-          countType     = "imageCountMoreThan"
-          countNumber   = 3
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 3
         }
         action = {
           type = "expire"
@@ -295,9 +305,9 @@ module "auto_reenable_lambda" {
   publish = true
 
   environment_variables = {
-    ENVIRONMENT              = var.environment
-    INCIDENT_TABLE           = aws_dynamodb_table.alarm_slack_mapping.name
-    SLACK_BOT_TOKEN          = local.slack_alert_config.slack_bot_token
+    ENVIRONMENT                   = var.environment
+    INCIDENT_TABLE                = aws_dynamodb_table.alarm_slack_mapping.name
+    SLACK_ALERT_CONFIG_SECRET_ARN = aws_secretsmanager_secret.slack_alert_config.arn
   }
 
   attach_policy_statements = true
@@ -318,6 +328,12 @@ module "auto_reenable_lambda" {
         "dynamodb:UpdateItem"
       ]
       resources = [aws_dynamodb_table.alarm_slack_mapping.arn]
+    }
+    secrets_manager = {
+      sid       = "AllowSecretsManagerRead"
+      effect    = "Allow"
+      actions   = ["secretsmanager:GetSecretValue"]
+      resources = [aws_secretsmanager_secret.slack_alert_config.arn]
     }
   }
 
@@ -343,9 +359,9 @@ module "auto_reenable_docker_image" {
         rulePriority = 1
         description  = "Keep last 3 images"
         selection = {
-          tagStatus     = "any"
-          countType     = "imageCountMoreThan"
-          countNumber   = 3
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 3
         }
         action = {
           type = "expire"

--- a/terraform/alert_system/secretsmanager.tf
+++ b/terraform/alert_system/secretsmanager.tf
@@ -7,11 +7,3 @@ resource "aws_secretsmanager_secret" "slack_alert_config" {
     Environment = var.environment
   }
 }
-
-data "aws_secretsmanager_secret_version" "slack_alert_config" {
-  secret_id = aws_secretsmanager_secret.slack_alert_config.id
-}
-
-locals {
-  slack_alert_config = jsondecode(data.aws_secretsmanager_secret_version.slack_alert_config.secret_string)
-}

--- a/terraform/alert_system/shared_layer/utils/__init__.py
+++ b/terraform/alert_system/shared_layer/utils/__init__.py
@@ -1,5 +1,6 @@
 from .alarm_state_enum import CloudWatchAlarmState, IncidentState
 from .slack_blocks import build_blocks
+from .slack_config import get_slack_config
 from .slack_incident import (
     handle_button_action,
     post_incident_message,
@@ -16,5 +17,6 @@ __all__ = [
     "update_incident_message",
     "post_thread_message",
     "handle_button_action",
+    "get_slack_config",
     "verify_slack_request_signature",
 ]

--- a/terraform/alert_system/shared_layer/utils/slack_config.py
+++ b/terraform/alert_system/shared_layer/utils/slack_config.py
@@ -1,0 +1,8 @@
+import os
+
+from aws_lambda_powertools.utilities.parameters import get_secret
+
+
+def get_slack_config():
+    secret_arn = os.environ["SLACK_ALERT_CONFIG_SECRET_ARN"]
+    return get_secret(secret_arn, transform="json")

--- a/terraform/alert_system/slack_alert/lambda_function.py
+++ b/terraform/alert_system/slack_alert/lambda_function.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 
 from botocore.exceptions import ClientError
 from cloudwatch_util import CloudWatchError, get_metric_chart
@@ -11,15 +10,16 @@ from utils import (
     CloudWatchAlarmState,
     IncidentState,
     build_blocks,
+    get_slack_config,
     post_incident_message,
 )
 
-SLACK_BOT_TOKEN = os.environ["SLACK_BOT_TOKEN"]
-SLACK_CHANNEL = os.environ["SLACK_CHANNEL"]
+slack_config = get_slack_config()
+SLACK_BOT_TOKEN = slack_config["slack_bot_token"]
+SLACK_CHANNEL = slack_config["slack_channel"]
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
-logger.info("Token prefix: %s", SLACK_BOT_TOKEN[:4])
 
 incident_repo = IncidentRepository()
 slack = WebClient(token=SLACK_BOT_TOKEN)

--- a/terraform/alert_system/slack_alert/requirements.txt
+++ b/terraform/alert_system/slack_alert/requirements.txt
@@ -1,1 +1,2 @@
 slack-sdk==3.33.4
+aws-lambda-powertools==3.30.0

--- a/terraform/alert_system/slack_interaction_handler/lambda_function.py
+++ b/terraform/alert_system/slack_interaction_handler/lambda_function.py
@@ -1,7 +1,6 @@
 import base64
 import json
 import logging
-import os
 import urllib.parse
 
 import boto3
@@ -9,15 +8,21 @@ from botocore.exceptions import ClientError
 from incident_repository import IncidentRepository
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
-from utils import build_blocks, handle_button_action, verify_slack_request_signature
+from utils import (
+    build_blocks,
+    get_slack_config,
+    handle_button_action,
+    verify_slack_request_signature,
+)
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 cw = boto3.client("cloudwatch")
 incident_repo = IncidentRepository()
-slack = WebClient(token=os.environ["SLACK_BOT_TOKEN"])
-slack_signing_secret = os.environ["SLACK_SIGNING_SECRET"]
+slack_config = get_slack_config()
+slack = WebClient(token=slack_config["slack_bot_token"])
+slack_signing_secret = slack_config["slack_signing_secret"]
 
 
 def lambda_handler(event, context):

--- a/terraform/alert_system/slack_interaction_handler/requirements.txt
+++ b/terraform/alert_system/slack_interaction_handler/requirements.txt
@@ -1,1 +1,2 @@
 slack-sdk==3.33.4
+aws-lambda-powertools==3.30.0


### PR DESCRIPTION
## Description

This PR refactors all AWS Secrets Manager interactions across `webhook_service`, `auth_service`, and `rsvp_service` to use **AWS Lambda Powertools Parameters** (v3.30.0) instead of raw boto3 calls.

### Motivation

Previously, each Lambda manually managed its own `boto3.client("secretsmanager")` instance, handled JSON parsing, and in some cases implemented ad-hoc in-memory caching via global variables. This resulted in repeated boilerplate and inconsistency across services.

Powertools Parameters provides:
- **Built-in in-process caching** (default 5-min TTL) — reduces Secrets Manager API calls per warm invocation
- **Automatic JSON transform** via `transform="json"` — eliminates manual `json.loads(response["SecretString"])`
- **Consistent error type** (`GetParameterError`) — makes exception handling predictable

### Changes per service

**`webhook_service/trigger_webhook/`**
- `utils.py`: Removed `SecretsManager` class; replaced with module-level `get_access_token()` using `get_secret(..., transform="json", force_fetch=True)`. `force_fetch=True` is intentional — access tokens are actively written by `auth_service` and must always be fetched fresh to avoid serving a stale token after rotation.
- `email_service.py`: Updated to import and call the new `get_access_token()` function directly; removed `EmailService.__init__` which previously existed solely to instantiate `SecretsManager`.

**`auth_service/refresh_service_accounts_token/`**
- `lambda_function.py`: Replaced `secrets_client.get_secret_value()` on the password read path with `get_secret(..., transform="json")`. The `update_secret` write path remains on boto3 — Powertools Parameters is read-only. Added `GetParameterError` to the `except` clause to properly catch Powertools-raised exceptions alongside `ClientError`.

**`rsvp_service/get_rsvp_status/` and `rsvp_service/update_rsvp/`**
- `jwt_util.py` (both): Removed manual `boto3.client("secretsmanager")` instantiation and the global `_jwt_secret_cache` variable. Replaced with `get_secret(jwt_secret_arn)` — Powertools handles caching transparently with the same effective behavior.

## Type of Change

- [ ] 🐛 Bug Fix (fixes an issue)
- [ ] ✨ New Feature (introduces a new feature)
- [ ] 💄 UI/UX (improves interface or user experience)
- [x] 🔨 Refactor (code refactoring)
- [ ] 📝 Documentation (updates documentation)
- [ ] 🔧 Configuration (changes configuration)
- [x] 🚀 Performance (improves performance)
- [ ] ✅ Test (related to tests)
- [ ] 🔒 Security (addresses security concerns)

## Related Issues

[SCRUM-622](https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-622)

## Testing

1. Deploy to the `preview` environment via the CI/CD pipeline.
2. Trigger the `webhook_service` with a valid SurveyCake webhook payload and verify the email is sent successfully (confirms `get_access_token` fetches a valid token).
3. Manually invoke the `refresh_service_accounts_token` Lambda and verify the response shows `"status": "success"` for both `surveycake` and `postman` accounts (confirms password retrieval and token update still work).
4. Call `GET /rsvp/{run_id_participant_id}/status` and `PATCH /rsvp/{run_id_participant_id}` with a valid JWT and verify 200 responses (confirms JWT secret retrieval via Powertools).
5. Postman collection tests run automatically in CI after deployment.

## Screenshots/Videos

N/A — backend refactor with no API contract changes.

## Checklist

- [x] I have tested these changes.
- [x] I have updated the relevant documentation.
- [x] My code adheres to the project's code standards.
- [x] I have addressed all console warnings/errors.
- [x] I have removed all `console.log` or `print()` statements.
- [ ] I have added necessary test cases.
- [x] All existing tests pass.

## Additional Notes

- The `update_secret` call in `auth_service` intentionally remains on raw boto3 — Powertools Parameters does not support write operations.
- `force_fetch=True` in `webhook_service` bypasses the Powertools cache for access tokens only. This is necessary because these tokens are short-lived credentials written by a separate Lambda (`auth_service`) and must be read fresh on every invocation.
- All secret path patterns are unchanged — this is a pure implementation swap with no AWS resource modifications.


[SCRUM-622]: https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ