### PR TITLE
[SCRUM-639] standardize resource tags

### DIFF
--- a/src/auth_service/terraform/api_gateway.tf
+++ b/src/auth_service/terraform/api_gateway.tf
@@ -2,10 +2,6 @@ locals {
   region             = var.aws_region
   custom_domain_name = "${var.environment}-${var.service_hyphen}-internal-api-tpet.aws-educate.tw"
   sub_domain_name    = "${var.environment}-${var.service_hyphen}-internal-api-tpet"
-
-  tags = {
-    Service = var.service_underscore
-  }
 }
 
 # Find a certificate that is issued
@@ -162,8 +158,6 @@ module "api_gateway" {
     throttling_burst_limit   = 100
     throttling_rate_limit    = 100
   }
-
-  tags = local.tags
 }
 
 resource "aws_route53_record" "api_gateway_custom_domain_record" {

--- a/src/auth_service/terraform/eventbridge.tf
+++ b/src/auth_service/terraform/eventbridge.tf
@@ -1,10 +1,6 @@
 # Create EventBridge scheduler group
 resource "aws_scheduler_schedule_group" "service_group" {
   name = "${var.environment}-${var.service_underscore}-schedule_group"
-
-  tags = {
-    Service = var.service_underscore
-  }
 }
 
 # Create EventBridge scheduler

--- a/src/auth_service/terraform/iam.tf
+++ b/src/auth_service/terraform/iam.tf
@@ -21,10 +21,6 @@ resource "aws_iam_role" "refresh_service_accounts_token_scheduler_role" {
       }
     ]
   })
-
-  tags = {
-    Service = var.service_underscore
-  }
 }
 
 # Create specific IAM policy for invoking the refresh token lambda

--- a/src/auth_service/terraform/lambda.tf
+++ b/src/auth_service/terraform/lambda.tf
@@ -85,12 +85,6 @@ module "health_check_lambda" {
     }
   }
 
-  tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-  }
-
 }
 
 module "health_check_docker_image" {
@@ -170,10 +164,7 @@ module "login_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -276,11 +267,6 @@ module "change_password_lambda" {
     }
   }
 
-  tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-  }
   ######################
   # Additional policies
   ######################
@@ -382,11 +368,6 @@ module "get_user_lambda" {
     }
   }
 
-  tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-  }
   ######################
   # Additional policies
   ######################
@@ -488,10 +469,7 @@ module "get_me_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -593,11 +571,6 @@ module "is_logged_in_lambda" {
     }
   }
 
-  tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-  }
   ######################
   # Additional policies
   ######################
@@ -700,11 +673,6 @@ module "refresh_service_accounts_token_lambda" {
     }
   }
 
-  tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-  }
   ######################
   # Additional policies
   ######################

--- a/src/auth_service/terraform/provider.tf
+++ b/src/auth_service/terraform/provider.tf
@@ -1,10 +1,13 @@
 provider "aws" {
   region = var.aws_region
+
   default_tags {
     tags = {
-      "Terraform"   = "true",
-      "Environment" = var.environment,
       "Project"     = "AWS Educate TPET"
+      "Service"     = var.service_underscore
+      "Environment" = var.environment
+      "Repository"  = "aws-educate-tw/aws-educate-tpet-backend"
+      "ManagedBy"   = "terraform"
     }
   }
 }

--- a/src/auth_service/terraform/secrets_manager.tf
+++ b/src/auth_service/terraform/secrets_manager.tf
@@ -3,10 +3,6 @@ resource "aws_secretsmanager_secret" "surveycake_service_account_access_token" {
   name        = "aws-educate-tpet/${var.environment}/service-accounts/surveycake/access-token"
   description = "Access token for AWS Eudcate TPET ${var.environment} SurveyCake service account"
 
-  tags = {
-    Service = var.service_underscore
-  }
-
   # Resource Policy
   policy = jsonencode({
     Version = "2012-10-17"
@@ -68,10 +64,6 @@ resource "aws_secretsmanager_secret_version" "surveycake_access_token" {
 resource "aws_secretsmanager_secret" "postman_service_account_access_token" {
   name        = "aws-educate-tpet/${var.environment}/service-accounts/postman/access-token"
   description = "Access token for AWS Eudcate TPET ${var.environment} Postman service account"
-
-  tags = {
-    Service = var.service_underscore
-  }
 
   # Resource Policy
   policy = jsonencode({

--- a/src/email_service/terraform/api_gateway.tf
+++ b/src/email_service/terraform/api_gateway.tf
@@ -2,10 +2,6 @@ locals {
   region             = var.aws_region
   custom_domain_name = "${var.environment}-${var.service_hyphen}-internal-api-tpet.${var.domain_name}"
   sub_domain_name    = "${var.environment}-${var.service_hyphen}-internal-api-tpet"
-
-  tags = {
-    Service = var.service_underscore
-  }
 }
 
 # Find a certificate that is issued
@@ -197,8 +193,6 @@ module "api_gateway" {
     throttling_burst_limit   = 100
     throttling_rate_limit    = 100
   }
-
-  tags = local.tags
 }
 
 resource "aws_route53_record" "api_gateway_custom_domain_record" {

--- a/src/email_service/terraform/lambda.tf
+++ b/src/email_service/terraform/lambda.tf
@@ -84,12 +84,6 @@ module "health_check_lambda" {
     }
   }
 
-  tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-  }
-
   ######################
   # Additional policies
   ######################
@@ -203,10 +197,7 @@ module "validate_input_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -353,10 +344,7 @@ module "auto_resume_aurora_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -515,10 +503,7 @@ module "upsert_run_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -677,10 +662,7 @@ module "create_email_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -840,10 +822,7 @@ module "send_email_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -1000,10 +979,7 @@ module "list_runs_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -1147,10 +1123,7 @@ module "create_run_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -1299,10 +1272,7 @@ module "get_run_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -1445,10 +1415,7 @@ module "list_emails_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies

--- a/src/email_service/terraform/provider.tf
+++ b/src/email_service/terraform/provider.tf
@@ -3,9 +3,11 @@ provider "aws" {
 
   default_tags {
     tags = {
-      "Terraform"   = "true",
-      "Environment" = var.environment,
       "Project"     = "AWS Educate TPET"
+      "Service"     = var.service_underscore
+      "Environment" = var.environment
+      "Repository"  = "aws-educate-tw/aws-educate-tpet-backend"
+      "ManagedBy"   = "terraform"
     }
   }
 }

--- a/src/email_service/terraform/rds.tf
+++ b/src/email_service/terraform/rds.tf
@@ -34,6 +34,4 @@ module "aurora_postgresql_v2" {
   instances = {
     one = {}
   }
-
-  tags = local.tags
 }

--- a/src/email_service/terraform/vpc.tf
+++ b/src/email_service/terraform/vpc.tf
@@ -48,9 +48,4 @@ module "vpc" {
   create_database_subnet_route_table = true
   enable_dns_hostnames               = true
   enable_dns_support                 = true
-
-  tags = {
-    Terraform = "true"
-    Service   = var.service_underscore
-  }
 }

--- a/src/file_service/terraform/api_gateway.tf
+++ b/src/file_service/terraform/api_gateway.tf
@@ -2,10 +2,6 @@ locals {
   region             = var.aws_region
   custom_domain_name = "${var.environment}-${var.service_hyphen}-internal-api-tpet.aws-educate.tw"
   sub_domain_name    = "${var.environment}-${var.service_hyphen}-internal-api-tpet"
-
-  tags = {
-    Service = var.service_underscore
-  }
 }
 
 # Find a certificate that is issued
@@ -184,8 +180,6 @@ module "api_gateway" {
     throttling_burst_limit   = 100
     throttling_rate_limit    = 100
   }
-
-  tags = local.tags
 }
 
 resource "aws_route53_record" "api_gateway_custom_domain_record" {

--- a/src/file_service/terraform/lambda.tf
+++ b/src/file_service/terraform/lambda.tf
@@ -73,12 +73,6 @@ module "health_check_lambda" {
     }
   }
 
-  tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-  }
-
 }
 
 module "health_check_docker_image" {
@@ -157,10 +151,7 @@ module "upload_multiple_file_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -283,10 +274,7 @@ module "list_files_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -411,10 +399,7 @@ module "get_file_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -535,10 +520,7 @@ module "get_template_variables_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
 
   ######################

--- a/src/file_service/terraform/provider.tf
+++ b/src/file_service/terraform/provider.tf
@@ -1,10 +1,13 @@
 provider "aws" {
   region = var.aws_region
+
   default_tags {
     tags = {
-      "Terraform"   = "true",
-      "Environment" = var.environment,
       "Project"     = "AWS Educate TPET"
+      "Service"     = var.service_underscore
+      "Environment" = var.environment
+      "Repository"  = "aws-educate-tw/aws-educate-tpet-backend"
+      "ManagedBy"   = "terraform"
     }
   }
 }

--- a/src/rsvp_service/terraform/api_gateway.tf
+++ b/src/rsvp_service/terraform/api_gateway.tf
@@ -2,10 +2,6 @@ locals {
   region             = var.aws_region
   custom_domain_name = "${var.environment}-${var.service_hyphen}-internal-api-tpet.${var.domain_name}"
   sub_domain_name    = "${var.environment}-${var.service_hyphen}-internal-api-tpet"
-
-  tags = {
-    Service = var.service_underscore
-  }
 }
 
 # Find a certificate that is issued
@@ -218,8 +214,6 @@ module "api_gateway" {
     }
 
   }
-
-  tags = local.tags
 }
 
 resource "aws_route53_record" "api_gateway_custom_domain_record" {

--- a/src/rsvp_service/terraform/lambda.tf
+++ b/src/rsvp_service/terraform/lambda.tf
@@ -84,10 +84,7 @@ module "update_rsvp_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
 
   ######################
@@ -205,10 +202,7 @@ module "get_rsvp_status_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
 
   ######################
@@ -324,10 +318,7 @@ module "verify_campaign_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
 
   ######################
@@ -433,10 +424,7 @@ module "upsert_run_configuration_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
 
   ######################
@@ -543,10 +531,7 @@ module "import_participant_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
 
   ######################
@@ -654,10 +639,7 @@ module "list_campaigns_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
 
   ######################
@@ -766,10 +748,7 @@ module "get_campaign_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
 
   ######################
@@ -875,10 +854,7 @@ module "create_campaign_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
 
   ######################
@@ -986,10 +962,7 @@ module "update_campaign_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore,
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
 
   ######################

--- a/src/rsvp_service/terraform/provider.tf
+++ b/src/rsvp_service/terraform/provider.tf
@@ -3,9 +3,11 @@ provider "aws" {
 
   default_tags {
     tags = {
-      "Terraform"   = "true",
-      "Environment" = var.environment,
       "Project"     = "AWS Educate TPET"
+      "Service"     = var.service_underscore
+      "Environment" = var.environment
+      "Repository"  = "aws-educate-tw/aws-educate-tpet-backend"
+      "ManagedBy"   = "terraform"
     }
   }
 }

--- a/src/webhook_service/terraform/api_gateway.tf
+++ b/src/webhook_service/terraform/api_gateway.tf
@@ -2,10 +2,6 @@ locals {
   region             = var.aws_region
   custom_domain_name = "${var.environment}-${var.service_hyphen}-internal-api-tpet.aws-educate.tw"
   sub_domain_name    = "${var.environment}-${var.service_hyphen}-internal-api-tpet"
-
-  tags = {
-    Service = var.service_underscore
-  }
 }
 
 # Find a certificate that is issued
@@ -195,8 +191,6 @@ module "api_gateway" {
     throttling_burst_limit   = 100
     throttling_rate_limit    = 100
   }
-
-  tags = local.tags
 }
 
 resource "aws_route53_record" "api_gateway_custom_domain_record" {

--- a/src/webhook_service/terraform/lambda.tf
+++ b/src/webhook_service/terraform/lambda.tf
@@ -74,12 +74,6 @@ module "health_check_lambda" {
     }
   }
 
-  tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-  }
-
 }
 
 module "health_check_docker_image" {
@@ -157,10 +151,7 @@ module "get_webhook_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -261,10 +252,7 @@ module "update_webhook_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -365,11 +353,6 @@ module "list_webhooks_lambda" {
     }
   }
 
-  tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-  }
   ######################
   # Additional policies
   ######################
@@ -476,10 +459,7 @@ module "save_webhook_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies
@@ -582,10 +562,7 @@ module "trigger_webhook_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies

--- a/src/webhook_service/terraform/provider.tf
+++ b/src/webhook_service/terraform/provider.tf
@@ -1,10 +1,13 @@
 provider "aws" {
   region = var.aws_region
+
   default_tags {
     tags = {
-      "Terraform"   = "true",
-      "Environment" = var.environment,
       "Project"     = "AWS Educate TPET"
+      "Service"     = var.service_underscore
+      "Environment" = var.environment
+      "Repository"  = "aws-educate-tw/aws-educate-tpet-backend"
+      "ManagedBy"   = "terraform"
     }
   }
 }

--- a/terraform/acm_shared_cert/provider.tf
+++ b/terraform/acm_shared_cert/provider.tf
@@ -1,11 +1,13 @@
 provider "aws" {
   region = var.aws_region
+
   default_tags {
     tags = {
-      "Terraform"   = "true",
-      "Environment" = var.environment,
       "Project"     = "AWS Educate TPET"
-      "Service"     = "acm_shared_cert"
+      "Service"     = "shared"
+      "Environment" = var.environment
+      "Repository"  = "aws-educate-tw/aws-educate-tpet-backend"
+      "ManagedBy"   = "terraform"
     }
   }
 }

--- a/terraform/cloudfront_for_apis/provider.tf
+++ b/terraform/cloudfront_for_apis/provider.tf
@@ -1,11 +1,13 @@
 provider "aws" {
   region = "us-east-1" # CloudFront expects ACM resources in us-east-1 region only
+
   default_tags {
     tags = {
-      "Terraform"   = "true",
-      "Environment" = "global",
       "Project"     = "AWS Educate TPET"
-      "Service"     = "cloudfront_for_apis"
+      "Service"     = "shared"
+      "Environment" = "shared"
+      "Repository"  = "aws-educate-tw/aws-educate-tpet-backend"
+      "ManagedBy"   = "terraform"
     }
   }
 }

--- a/terraform/cognito/provider.tf
+++ b/terraform/cognito/provider.tf
@@ -1,10 +1,13 @@
 provider "aws" {
   region = var.aws_region
+
   default_tags {
     tags = {
-      "Terraform"   = "true",
-      "Environment" = var.environment,
       "Project"     = "AWS Educate TPET"
+      "Service"     = "shared"
+      "Environment" = var.environment
+      "Repository"  = "aws-educate-tw/aws-educate-tpet-backend"
+      "ManagedBy"   = "terraform"
     }
   }
 }

--- a/terraform/forward_email/lambda.tf
+++ b/terraform/forward_email/lambda.tf
@@ -77,11 +77,6 @@ module "forward_email_lambda" {
     }
   }
 
-  tags = {
-    "Terraform"   = "true"
-    "Environment" = var.environment
-  }
-
   ######################
   # Additional policies
   ######################

--- a/terraform/forward_email/provider.tf
+++ b/terraform/forward_email/provider.tf
@@ -1,10 +1,13 @@
 provider "aws" {
   region = var.aws_region
+
   default_tags {
     tags = {
-      "Terraform"   = "true",
-      "Environment" = var.environment,
       "Project"     = "AWS Educate TPET"
+      "Service"     = "shared"
+      "Environment" = var.environment
+      "Repository"  = "aws-educate-tw/aws-educate-tpet-backend"
+      "ManagedBy"   = "terraform"
     }
   }
 }

--- a/terraform/lambda_authorizer/lambda.tf
+++ b/terraform/lambda_authorizer/lambda.tf
@@ -88,10 +88,7 @@ module "lambda_authorizer_lambda" {
   }
 
   tags = {
-    "Terraform"   = "true",
-    "Environment" = var.environment,
-    "Service"     = var.service_underscore
-    "Prewarm"     = "true"
+    "Prewarm" = "true"
   }
   ######################
   # Additional policies

--- a/terraform/lambda_authorizer/provider.tf
+++ b/terraform/lambda_authorizer/provider.tf
@@ -1,10 +1,13 @@
 provider "aws" {
   region = var.aws_region
+
   default_tags {
     tags = {
-      "Terraform"   = "true",
-      "Environment" = var.environment,
       "Project"     = "AWS Educate TPET"
+      "Service"     = var.service_underscore
+      "Environment" = var.environment
+      "Repository"  = "aws-educate-tw/aws-educate-tpet-backend"
+      "ManagedBy"   = "terraform"
     }
   }
 }

--- a/terraform/lambda_warmer/provider.tf
+++ b/terraform/lambda_warmer/provider.tf
@@ -1,10 +1,13 @@
 provider "aws" {
   region = var.aws_region
+
   default_tags {
     tags = {
-      "Terraform"   = "true",
-      "Environment" = var.environment,
       "Project"     = "AWS Educate TPET"
+      "Service"     = "shared"
+      "Environment" = var.environment
+      "Repository"  = "aws-educate-tw/aws-educate-tpet-backend"
+      "ManagedBy"   = "terraform"
     }
   }
 }

--- a/terraform/modules/public_s3/main.tf
+++ b/terraform/modules/public_s3/main.tf
@@ -2,8 +2,7 @@ resource "aws_s3_bucket" "aws_educate_tpet_bucket" {
   bucket = "${var.environment}-aws-educate-tpet-bucket"
 
   tags = {
-    Name        = "${var.environment}-aws-educate-tpet-bucket"
-    Environment = var.environment
+    Name = "${var.environment}-aws-educate-tpet-bucket"
   }
 }
 

--- a/terraform/modules/public_s3/provider.tf
+++ b/terraform/modules/public_s3/provider.tf
@@ -1,10 +1,13 @@
 provider "aws" {
   region = var.aws_region
+
   default_tags {
     tags = {
-      "Terraform"   = "true",
-      "Environment" = var.environment,
       "Project"     = "AWS Educate TPET"
+      "Service"     = "shared"
+      "Environment" = var.environment
+      "Repository"  = "aws-educate-tw/aws-educate-tpet-backend"
+      "ManagedBy"   = "terraform"
     }
   }
 }

--- a/terraform/storage/s3/provider.tf
+++ b/terraform/storage/s3/provider.tf
@@ -1,10 +1,13 @@
 provider "aws" {
   region = var.aws_region
+
   default_tags {
     tags = {
-      "Terraform"   = "true",
-      "Environment" = var.environment,
       "Project"     = "AWS Educate TPET"
+      "Service"     = "shared"
+      "Environment" = var.environment
+      "Repository"  = "aws-educate-tw/aws-educate-tpet-backend"
+      "ManagedBy"   = "terraform"
     }
   }
 }

--- a/terraform/storage/s3/s3.tf
+++ b/terraform/storage/s3/s3.tf
@@ -15,8 +15,7 @@ resource "aws_s3_bucket" "aws_educate_tpet_bucket" {
   bucket = local.public_bucket_name
 
   tags = {
-    Name        = local.public_bucket_name
-    Environment = var.environment
+    Name = local.public_bucket_name
   }
 }
 
@@ -67,7 +66,6 @@ resource "aws_s3_bucket" "aws_educate_tpet_private_bucket" {
   bucket = local.private_bucket_name
 
   tags = {
-    Name        = local.private_bucket_name
-    Environment = var.environment
+    Name = local.private_bucket_name
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 🎉
-->

<!-- markdownlint-disable MD041 -->
## Description
<!--
Provide a brief description of this PR:
- What issue does this PR address?
- Why is this change necessary?
- How was it implemented?
-->

### Background

The ambassador AWS account hosts multiple projects and microservices, each using many types of AWS resources. Tags were applied inconsistently across those resources (different keys per resource), which makes cost attribution in Cost Explorer unreliable and hard to trace. To make cost ownership transparent, we need a consistent, required tag set so we can activate Cost Allocation Tags and slice costs by project / service / environment.

### Changes

- Define the 5 required tags — `Project`, `Service`, `Environment`, `Repository`, `ManagedBy` — in each config's `provider.tf` `default_tags`, so every taggable resource inherits them automatically.
- Replace the old `Terraform = "true"` tag with `ManagedBy = "terraform"`, and add the new `Repository` and `Service` tags.
- Remove redundant resource-level tag blocks that duplicated the required tags; keep optional tags only where they apply (`Prewarm`, `Name`).
- Service naming: real microservices use their own name (`var.service_underscore`); cross-service / shared infra uses `"shared"`. `cloudfront_for_apis` also uses `Environment = "shared"` (was `"global"`).

## Type of Change
<!--
Select the type(s) of changes made (you can select multiple):
-->
- [ ] 🐛 Bug Fix (fixes an issue)
- [ ] ✨ New Feature (introduces a new feature)
- [ ] 💄 UI/UX (improves interface or user experience)
- [x] 🔨 Refactor (code refactoring)
- [ ] 📝 Documentation (updates documentation)
- [x] 🔧 Configuration (changes configuration)
- [ ] 🚀 Performance (improves performance)
- [ ] ✅ Test (related to tests)
- [ ] 🔒 Security (addresses security concerns)

## Related Issues
<!--
List related issue numbers or links:
Example: Closes SCRUM-123, Relates to SCRUM-456
-->

Relates to [SCRUM-639](https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-639?atlOrigin=eyJpIjoiNzZhODNkMTBjNTIzNGJiZmEyZDc1NWU4NGIyNDY2ODQiLCJwIjoiaiJ9)

## Testing
<!--
Describe how these changes were tested:
- What tests were performed?
- How were these changes verified?
- Are there any specific test steps required?
-->

- Applied in the local-dev environment successfully and reviewed every plan to confirm the tag changes are applied in place, with no stateful resources destroyed.
- (By Claude) Verified all Terraform-managed resources (except `lambda_warmer`, see Additional Notes) carry the 5 required tags via the Resource Groups Tagging API — **159 resources, 0 missing**:
  ```bash
  aws resourcegroupstaggingapi get-resources --region us-west-2 --output json \
   | jq -r '[.ResourceTagMappingList[] | {arn:.ResourceARN, keys:[.Tags[].Key]}]
     | map(select(.keys | index("ManagedBy")))
     | map(select((["Project","Service","Environment","Repository","ManagedBy"] - .keys) | length > 0))
     | if length == 0 then "✅ all tagged" else (.[] | "⚠️ missing: \(.arn)") end'
  ```

## Screenshots/Videos
<!--
Provide screenshots or videos to demonstrate the changes (if applicable).
-->

N/A

## Checklist
<!--
Ensure the following items are checked before submitting the PR:
-->
- [x] I have tested these changes.
- [x] I have updated the relevant documentation.
- [x] My code adheres to the project’s code standards.
- [x] I have addressed all console warnings/errors.
- [x] I have removed all `console.log` or `print()` statements.
- [ ] I have added necessary test cases.
- [x] All existing tests pass.

## Additional Notes
<!--
Add any other relevant notes or considerations:
-->

- `terraform/dev|prod|poc` are old, outdated code, so we left them untouched here; they will be removed in [SCRUM-651](https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-651?atlOrigin=eyJpIjoiZTVhMmZlYTE1M2I1NGM2NmE5NDZjNzg2OGMyM2QxZjEiLCJwIjoiaiJ9).
- `lambda_warmer` can't be standardized from this repo: its resources come from the external module [aws-educate-tw/tag-based-lambda-warmer](https://github.com/aws-educate-tw/terraform-aws-tag-based-lambda-warmer), which declares its own `provider` block hardcoding `Terraform = "true"` and exposes no `tags` variable. The live resources keep the old tag until that module is updated and re-released.

<!--
Reminder:
Before submitting your PR, please review the **Coding Guidelines**: https://aws-educate-tw.notion.site/TPET-Backend-Coding-Guidelines-12e6bfee681780ac89c3cf43854380d4?pvs=4
-->

<!-- markdownlint-enable MD041 -->


[SCRUM-639]: https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ